### PR TITLE
Disabling incremental compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <useIncrementalCompilation>false</useIncrementalCompilation>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The incremental compiler can cause javac to crash on 'non-clean' projects.  This option prevents it from running and therefore should avoid the bug.

#93