### PR TITLE
Preventing svg diagrams from corrupting each other

### DIFF
--- a/waltz-ng/client/svg-diagram/directives/svg-diagrams.html
+++ b/waltz-ng/client/svg-diagram/directives/svg-diagrams.html
@@ -1,9 +1,14 @@
 <div>
     <uib-tabset>
         <uib-tab heading='{{ diagram.name }}'
-                 ng-repeat="diagram in ctrl.diagrams | orderBy:'priority'">
-            <waltz-svg-diagram diagram="diagram" block-processor="ctrl.blockProcessor">
-            </waltz-svg-diagram>
+                 ng-repeat="diagram in ctrl.diagrams | orderBy:'priority'"
+                 deselect="ctrl.hide(diagram)"
+                 select="ctrl.show(diagram)">
+            <div ng-if="diagram.visible">
+                <waltz-svg-diagram diagram="diagram"
+                                   block-processor="ctrl.blockProcessor">
+                </waltz-svg-diagram>
+            </div>
             <hr class="waltz-hr-dotted">
             <div class="text-muted">
                 {{ diagram.description }}

--- a/waltz-ng/client/svg-diagram/directives/svg-diagrams.js
+++ b/waltz-ng/client/svg-diagram/directives/svg-diagrams.js
@@ -1,3 +1,16 @@
+function controller() {
+
+    const vm = this;
+
+    vm.show = (diagram) => {
+        diagram.visible = true;
+
+    };
+
+    vm.hide = (diagram) => {
+        diagram.visible = false;
+    };
+}
 
 
 export default () => ({
@@ -10,5 +23,5 @@ export default () => ({
         blockProcessor: '='
     },
     controllerAs: 'ctrl',
-    controller: () => {}
+    controller
 });


### PR DESCRIPTION
Visio inlines a CSS block which corrupts other diagrams on the page.
Solution is to ensure the diagram is not rendered when not visible (as opposed
to being hidden)

#95