### PR TITLE
Softcoding schema in build file

### DIFF
--- a/waltz-data/pom.xml
+++ b/waltz-data/pom.xml
@@ -126,7 +126,7 @@
                             <name>org.jooq.util.mariadb.MariaDBDatabase</name>
                             <includes>.*</includes>
                             <excludes></excludes>
-                            <inputSchema>scratch</inputSchema>
+                            <inputSchema>${database.schema}</inputSchema>
                             <outputSchemaToDefault>true</outputSchemaToDefault>
                         </database>
                         <target>


### PR DESCRIPTION
- added 'database.schema' to waltz.properties

#96