### PR TITLE
Truncate long titles in grid editor

### DIFF
--- a/waltz-ng/client/common/index.js
+++ b/waltz-ng/client/common/index.js
@@ -225,23 +225,6 @@ export function initialiseData(vm, initData) {
 }
 
 
-export function stringToBoolean(string){
-    switch(string.toLowerCase().trim()){
-        case "true":
-        case "yes":
-        case "1":
-            return true;
-        case "false":
-        case "no":
-        case "0":
-        case null:
-        case undefined:
-            return false;
-        default:
-            return Boolean(string);
-    }
-}
-
 
 /**
  * Invokes a function and also passes in any provided arguments in order

--- a/waltz-ng/client/common/string-utils.js
+++ b/waltz-ng/client/common/string-utils.js
@@ -1,0 +1,79 @@
+/*
+ * Waltz - Enterprise Architecture
+ * Copyright (C) 2016  Khartec Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Truncates via cutting out middle of string and replacing with separator
+ *
+ * i.e.
+ *
+ * truncateMiddle('abcdefghijkl', 7, '...') => 'ab...kl'
+ *
+ * @param origStr
+ * @param maxLength
+ * @param separator
+ * @returns {*}
+ */
+export function truncateMiddle(origStr = '',
+                         maxLength = 16,
+                         separator = ' ... ') {
+    if (origStr.length <= maxLength) {
+        return origStr;
+    }
+
+    const sepLength = separator.length;
+    const charsToShow = maxLength - sepLength;
+
+    const preLength = Math.ceil(charsToShow/2);
+    const postLength = Math.floor(charsToShow/2);
+
+    const pre = origStr.substr(0, preLength);
+    const post = origStr.substr(origStr.length - postLength)
+
+    return pre + separator + post;
+}
+
+
+/**
+ * Attempts to convert a string to a boolean using some common terms
+ * (case insensitive)
+ *
+ * - true | false
+ * - yes | no
+ * - 1 | 0
+ *
+ * If no matches from above, then reverts to `Boolean(str)`
+ *
+ * @param str
+ * @returns {boolean}
+ */
+export function stringToBoolean(str = ''){
+    switch(str.toLowerCase().trim()){
+        case "true":
+        case "yes":
+        case "1":
+            return true;
+        case "false":
+        case "no":
+        case "0":
+        case null:
+        case undefined:
+            return false;
+        default:
+            return Boolean(str);
+    }
+}

--- a/waltz-ng/client/perspective/components/grid/perspective-grid.js
+++ b/waltz-ng/client/perspective/components/grid/perspective-grid.js
@@ -418,7 +418,6 @@ function drawColTitles(elem, axis) {
         .filter(d => d.measurable.name.length > 32)
         .append('title')
         .text(d => d.measurable.name)
-
         ;
 
     colTitles

--- a/waltz-ng/client/perspective/components/grid/perspective-grid.js
+++ b/waltz-ng/client/perspective/components/grid/perspective-grid.js
@@ -23,7 +23,9 @@ import {path} from 'd3-path';
 import {nest} from 'd3-collection';
 import {initialiseData} from '../../../common';
 import {ragColorScale} from '../../../common/colors';
+import {truncateMiddle} from '../../../common/string-utils';
 import {mkPerspective} from '../../perpective-utilities';
+
 
 
 /**
@@ -364,9 +366,12 @@ function drawRowTitles(elem, axis) {
     const drawText = (selection) => selection
         .append('text')
         .classed('row-title', true)
-        .text(d => d.measurable.name)
+        .text(d => truncateMiddle(d.measurable.name, 32))
         .attr('text-anchor', 'end')
         .attr('transform', d => `translate(-${labelPadding},  ${scales.y(d.measurable.id) + scales.y.bandwidth() / 2})`)
+        .filter(d => d.measurable.name.length > 32)
+        .append('title')
+        .text(d => d.measurable.name)
         ;
 
     const rowTitles = elem
@@ -406,10 +411,14 @@ function drawColTitles(elem, axis) {
     const drawText = selection => selection
         .append('text')
         .classed('col-title', true)
-        .text(d => d.measurable.name)
+        .text(d => truncateMiddle(d.measurable.name, 32))
         .attr('text-anchor', 'start')
         .attr('transform', d =>
             `translate(${scales.x(d.measurable.id) + scales.x.bandwidth() / 3}, -${labelPadding}) rotate(-20)`)
+        .filter(d => d.measurable.name.length > 32)
+        .append('title')
+        .text(d => d.measurable.name)
+
         ;
 
     colTitles

--- a/waltz-ng/client/perspective/components/grid/perspective-grid.js
+++ b/waltz-ng/client/perspective/components/grid/perspective-grid.js
@@ -74,7 +74,7 @@ const labelIndicatorPadding = 4;
 const labelPadding = labelIndicatorSize + labelIndicatorPadding * 2;
 const cellWidth = 40;
 const cellHeight = 35;
-
+const maxLabelLength = 32;
 
 /**
  * { mA -> mB -> { measurableA, measurableB, rating } }
@@ -366,10 +366,10 @@ function drawRowTitles(elem, axis) {
     const drawText = (selection) => selection
         .append('text')
         .classed('row-title', true)
-        .text(d => truncateMiddle(d.measurable.name, 32))
+        .text(d => truncateMiddle(d.measurable.name, maxLabelLength))
         .attr('text-anchor', 'end')
         .attr('transform', d => `translate(-${labelPadding},  ${scales.y(d.measurable.id) + scales.y.bandwidth() / 2})`)
-        .filter(d => d.measurable.name.length > 32)
+        .filter(d => d.measurable.name.length > maxLabelLength)
         .append('title')
         .text(d => d.measurable.name)
         ;
@@ -411,11 +411,11 @@ function drawColTitles(elem, axis) {
     const drawText = selection => selection
         .append('text')
         .classed('col-title', true)
-        .text(d => truncateMiddle(d.measurable.name, 32))
+        .text(d => truncateMiddle(d.measurable.name, maxLabelLength))
         .attr('text-anchor', 'start')
         .attr('transform', d =>
             `translate(${scales.x(d.measurable.id) + scales.x.bandwidth() / 3}, -${labelPadding}) rotate(-20)`)
-        .filter(d => d.measurable.name.length > 32)
+        .filter(d => d.measurable.name.length > maxLabelLength)
         .append('title')
         .text(d => d.measurable.name)
         ;

--- a/waltz-ng/client/user/services/user-preference-service.js
+++ b/waltz-ng/client/user/services/user-preference-service.js
@@ -18,7 +18,7 @@
  */
 
 import _ from "lodash";
-import {stringToBoolean} from "../../common";
+import {stringToBoolean} from "../../common/string-utils";
 
 let preferencePromise = null;
 

--- a/waltz-ng/client/widgets/section.js
+++ b/waltz-ng/client/widgets/section.js
@@ -16,7 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {stringToBoolean, initialiseData} from "../common";
+import {initialiseData} from "../common";
+import {stringToBoolean} from "../common/string-utils";
 
 
 const bindings = {


### PR DESCRIPTION
- started pulling functions out of `common/index.js` into more targetted `xyz-utils.js` files

#1485