### PR TITLE
Section nav links now block level elements

### DIFF
--- a/waltz-ng/client/dynamic-section/components/dynamic-section-navigation/dynamic-section-navigation.scss
+++ b/waltz-ng/client/dynamic-section/components/dynamic-section-navigation/dynamic-section-navigation.scss
@@ -45,6 +45,10 @@
                 background-color: #f4f4f4;
             }
             @include transition(background-color 300ms linear);
+
+            a {
+                display: block;
+            }
         }
     }
 


### PR DESCRIPTION
- allows entire 'button' to be clicked rather than just the image/text
#2711