### PR TITLE
Allow waltz-entity-links to open new window/tab

### DIFF
--- a/waltz-ng/client/common/components/entity-link/entity-link.html
+++ b/waltz-ng/client/common/components/entity-link/entity-link.html
@@ -1,12 +1,18 @@
 <!-- ng-href is used here so that the links get updated when entityRef changes -->
 <!-- eg: when used in a ui-grid cell template -->
 <a ng-if="$ctrl.viewUrl"
-   ng-href="{{ $ctrl.viewUrl }}">
+   ng-href="{{ $ctrl.viewUrl }}"
+   ng-attr-target="{{ $ctrl.target }}"
+   class="waltz-visibility-parent">
 
     <waltz-entity-icon-label entity-ref="$ctrl.entityRef"
                              icon-placement="$ctrl.iconPlacement"
                              tooltip-placement="$ctrl.tooltipPlacement">
     </waltz-entity-icon-label>
+    <waltz-icon ng-if='$ctrl.target === "_blank"'
+                class="waltz-visibility-child-30"
+                name="external-link">
+    </waltz-icon>
 </a>
 
 <waltz-entity-icon-label entity-ref="$ctrl.entityRef"

--- a/waltz-ng/client/common/components/entity-link/entity-link.js
+++ b/waltz-ng/client/common/components/entity-link/entity-link.js
@@ -24,6 +24,7 @@ import {kindToViewState} from "../../../common/link-utils";
 const bindings = {
     entityRef: '<',
     iconPlacement: '<',
+    target: '@', /** if '_blank' the external icon is shown **/
     tooltipPlacement: '<'
 };
 


### PR DESCRIPTION
Waltz entity links can be passed a target='_blank' param to instruct
them to open new window/tab.

#3033