### PR TITLE
Add lgtm.yml build configuration for lgtm.com Java analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,5 @@
+extraction:
+  java:
+    after_prepare:
+      # Disable modules that require a running SQL server in order to build
+      - sed -i -e '/\s*<module>waltz-\(service\|web\|jobs\|data\|schema\)<\/module>/d' pom.xml


### PR DESCRIPTION
This build configuration enables Java analysis on LGTM.com. As discussed in #3097 with @davidwatkins73: a large part of the Java build process depends on generating code, which requires a running SQL server. For now I've disabled that module (`waltz-schema`) and all modules that depend on it by patching the `pom.xml`.

When analyzing a revision, LGTM will always use the `lgtm.yml` file that is present in that revision. So if the build process ever changes, all you have to do is update this file. The build is very configurable; see https://lgtm.com/help/lgtm/lgtm.yml-configuration-file

(Full disclosure: I'm part of the team that build LGTM.com)