### PR TITLE
Db contrib/waltz 4259 selectors

### DIFF
--- a/waltz-data/src/main/java/com/khartec/waltz/data/GenericSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/GenericSelectorFactory.java
@@ -15,42 +15,19 @@ import com.khartec.waltz.model.application.ApplicationIdSelectionOptions;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.impl.DSL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
 
-@Service
 public class GenericSelectorFactory {
 
-    private final ApplicationIdSelectorFactory applicationIdSelectorFactory;
-    private final ChangeInitiativeIdSelectorFactory changeInitiativeIdSelectorFactory;
-    private final ChangeUnitIdSelectorFactory changeUnitIdSelectorFactory;
-    private final DataTypeIdSelectorFactory dataTypeIdSelectorFactory;
-    private final FlowDiagramIdSelectorFactory flowDiagramIdSelectorFactory;
-    private final LogicalFlowIdSelectorFactory logicalFlowIdSelectorFactory;
-    private final MeasurableIdSelectorFactory measurableIdSelectorFactory;
-    private final OrganisationalUnitIdSelectorFactory organisationalUnitIdSelectorFactory;
-
-    @Autowired
-    public GenericSelectorFactory(ApplicationIdSelectorFactory applicationIdSelectorFactory,
-                                  ChangeInitiativeIdSelectorFactory changeInitiativeIdSelectorFactory,
-                                  ChangeUnitIdSelectorFactory changeUnitIdSelectorFactory,
-                                  DataTypeIdSelectorFactory dataTypeIdSelectorFactory,
-                                  FlowDiagramIdSelectorFactory flowDiagramIdSelectorFactory,
-                                  LogicalFlowIdSelectorFactory logicalFlowIdSelectorFactory,
-                                  MeasurableIdSelectorFactory measurableIdSelectorFactory,
-                                  OrganisationalUnitIdSelectorFactory organisationalUnitIdSelectorFactory) {
-
-        this.applicationIdSelectorFactory = applicationIdSelectorFactory;
-        this.changeInitiativeIdSelectorFactory = changeInitiativeIdSelectorFactory;
-        this.changeUnitIdSelectorFactory = changeUnitIdSelectorFactory;
-        this.dataTypeIdSelectorFactory = dataTypeIdSelectorFactory;
-        this.flowDiagramIdSelectorFactory = flowDiagramIdSelectorFactory;
-        this.logicalFlowIdSelectorFactory = logicalFlowIdSelectorFactory;
-        this.measurableIdSelectorFactory = measurableIdSelectorFactory;
-        this.organisationalUnitIdSelectorFactory = organisationalUnitIdSelectorFactory;
-    }
+    private final ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
+    private final ChangeInitiativeIdSelectorFactory changeInitiativeIdSelectorFactory = new ChangeInitiativeIdSelectorFactory();
+    private final ChangeUnitIdSelectorFactory changeUnitIdSelectorFactory = new ChangeUnitIdSelectorFactory();
+    private final DataTypeIdSelectorFactory dataTypeIdSelectorFactory = new DataTypeIdSelectorFactory();
+    private final FlowDiagramIdSelectorFactory flowDiagramIdSelectorFactory = new FlowDiagramIdSelectorFactory();
+    private final LogicalFlowIdSelectorFactory logicalFlowIdSelectorFactory = new LogicalFlowIdSelectorFactory();
+    private final MeasurableIdSelectorFactory measurableIdSelectorFactory = new MeasurableIdSelectorFactory();
+    private final OrganisationalUnitIdSelectorFactory organisationalUnitIdSelectorFactory = new OrganisationalUnitIdSelectorFactory();
 
 
     public GenericSelector apply(IdSelectionOptions selectionOptions) {

--- a/waltz-data/src/main/java/com/khartec/waltz/data/bookmark/BookmarkIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/bookmark/BookmarkIdSelectorFactory.java
@@ -8,22 +8,12 @@ import com.khartec.waltz.schema.tables.Bookmark;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.impl.DSL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
-import static com.khartec.waltz.common.Checks.checkNotNull;
-
-@Service
 public class BookmarkIdSelectorFactory implements IdSelectorFactory {
     private static final Bookmark bk = Bookmark.BOOKMARK.as("bk");
 
-    private final GenericSelectorFactory genericSelectorFactory;
+    private final GenericSelectorFactory genericSelectorFactory = new GenericSelectorFactory();
 
-    @Autowired
-    public BookmarkIdSelectorFactory(GenericSelectorFactory genericSelectorFactory) {
-        checkNotNull(genericSelectorFactory, "genericSelectorFactory cannot be null");
-        this.genericSelectorFactory = genericSelectorFactory;
-    }
 
     @Override
     public Select<Record1<Long>> apply(IdSelectionOptions selectionOptions) {

--- a/waltz-data/src/main/java/com/khartec/waltz/data/change_initiative/ChangeInitiativeIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/change_initiative/ChangeInitiativeIdSelectorFactory.java
@@ -24,39 +24,25 @@ import com.khartec.waltz.data.orgunit.OrganisationalUnitIdSelectorFactory;
 import com.khartec.waltz.model.EntityKind;
 import com.khartec.waltz.model.EntityReference;
 import com.khartec.waltz.model.IdSelectionOptions;
-import org.jooq.DSLContext;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.SelectConditionStep;
 import org.jooq.impl.DSL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
-import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.data.SelectorUtilities.ensureScopeIsExact;
 import static com.khartec.waltz.schema.tables.ChangeInitiative.CHANGE_INITIATIVE;
 import static com.khartec.waltz.schema.tables.EntityRelationship.ENTITY_RELATIONSHIP;
 import static com.khartec.waltz.schema.tables.FlowDiagramEntity.FLOW_DIAGRAM_ENTITY;
 import static com.khartec.waltz.schema.tables.Involvement.INVOLVEMENT;
 import static com.khartec.waltz.schema.tables.Person.PERSON;
-import static org.jooq.impl.DSL.selectDistinct;
 
-@Service
 public class ChangeInitiativeIdSelectorFactory extends AbstractIdSelectorFactory {
 
-    private final OrganisationalUnitIdSelectorFactory organisationalUnitIdSelectorFactory;
-    private final DSLContext dsl;
+    private final OrganisationalUnitIdSelectorFactory organisationalUnitIdSelectorFactory = new OrganisationalUnitIdSelectorFactory();
 
 
-    @Autowired
-    public ChangeInitiativeIdSelectorFactory(DSLContext dsl,
-                                             OrganisationalUnitIdSelectorFactory organisationalUnitIdSelectorFactory) {
-        super(dsl, EntityKind.CHANGE_INITIATIVE);
-
-        checkNotNull(organisationalUnitIdSelectorFactory, "organisationalUnitIdSelectorFactory cannot be null");
-
-        this.dsl = dsl;
-        this.organisationalUnitIdSelectorFactory = organisationalUnitIdSelectorFactory;
+    public ChangeInitiativeIdSelectorFactory() {
+        super(EntityKind.CHANGE_INITIATIVE);
     }
 
 
@@ -88,7 +74,8 @@ public class ChangeInitiativeIdSelectorFactory extends AbstractIdSelectorFactory
 
     private Select<Record1<Long>> mkForFlowDiagram(IdSelectionOptions options) {
         ensureScopeIsExact(options);
-        return dsl.selectDistinct(FLOW_DIAGRAM_ENTITY.ENTITY_ID)
+        return DSL
+                .selectDistinct(FLOW_DIAGRAM_ENTITY.ENTITY_ID)
                 .from(FLOW_DIAGRAM_ENTITY)
                 .where(FLOW_DIAGRAM_ENTITY.ENTITY_KIND.eq(EntityKind.CHANGE_INITIATIVE.name()))
                 .and(FLOW_DIAGRAM_ENTITY.DIAGRAM_ID.eq(options.entityReference().id()));
@@ -101,7 +88,7 @@ public class ChangeInitiativeIdSelectorFactory extends AbstractIdSelectorFactory
                 .from(PERSON)
                 .where(PERSON.ID.eq(options.entityReference().id()));
 
-        return dsl.selectDistinct(CHANGE_INITIATIVE.ID)
+        return DSL.selectDistinct(CHANGE_INITIATIVE.ID)
                 .from(CHANGE_INITIATIVE)
                 .innerJoin(INVOLVEMENT)
                 .on(INVOLVEMENT.ENTITY_ID.eq(CHANGE_INITIATIVE.ID))
@@ -113,7 +100,7 @@ public class ChangeInitiativeIdSelectorFactory extends AbstractIdSelectorFactory
     private Select<Record1<Long>> mkForOrgUnit(IdSelectionOptions options) {
         Select<Record1<Long>> ouSelector = organisationalUnitIdSelectorFactory.apply(options);
 
-        return dsl
+        return DSL
                 .selectDistinct(CHANGE_INITIATIVE.ID)
                 .from(CHANGE_INITIATIVE)
                 .where(CHANGE_INITIATIVE.ORGANISATIONAL_UNIT_ID.in(ouSelector));
@@ -129,13 +116,15 @@ public class ChangeInitiativeIdSelectorFactory extends AbstractIdSelectorFactory
     private Select<Record1<Long>> mkForRef(IdSelectionOptions options) {
         EntityReference ref = options.entityReference();
 
-        Select<Record1<Long>> aToB = selectDistinct(ENTITY_RELATIONSHIP.ID_A)
+        Select<Record1<Long>> aToB = DSL
+                .selectDistinct(ENTITY_RELATIONSHIP.ID_A)
                 .from(ENTITY_RELATIONSHIP)
                 .where(ENTITY_RELATIONSHIP.KIND_A.eq(EntityKind.CHANGE_INITIATIVE.name()))
                 .and(ENTITY_RELATIONSHIP.KIND_B.eq(ref.kind().name()))
                 .and(ENTITY_RELATIONSHIP.ID_B.eq(ref.id()));
 
-        Select<Record1<Long>> bToA = selectDistinct(ENTITY_RELATIONSHIP.ID_B)
+        Select<Record1<Long>> bToA = DSL
+                .selectDistinct(ENTITY_RELATIONSHIP.ID_B)
                 .from(ENTITY_RELATIONSHIP)
                 .where(ENTITY_RELATIONSHIP.KIND_B.eq(EntityKind.CHANGE_INITIATIVE.name()))
                 .and(ENTITY_RELATIONSHIP.KIND_A.eq(ref.kind().name()))

--- a/waltz-data/src/main/java/com/khartec/waltz/data/change_set/ChangeSetIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/change_set/ChangeSetIdSelectorFactory.java
@@ -27,25 +27,14 @@ import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.SelectConditionStep;
 import org.jooq.impl.DSL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.schema.Tables.CHANGE_SET;
 import static com.khartec.waltz.schema.tables.ChangeUnit.CHANGE_UNIT;
 
-@Service
 public class ChangeSetIdSelectorFactory implements IdSelectorFactory {
 
-    private final ChangeUnitIdSelectorFactory changeUnitIdSelectorFactory;
-
-
-    @Autowired
-    public ChangeSetIdSelectorFactory(ChangeUnitIdSelectorFactory changeUnitIdSelectorFactory) {
-        checkNotNull(changeUnitIdSelectorFactory, "changeUnitIdSelectorFactory cannot be null");
-
-        this.changeUnitIdSelectorFactory = changeUnitIdSelectorFactory;
-    }
+    private final ChangeUnitIdSelectorFactory changeUnitIdSelectorFactory = new ChangeUnitIdSelectorFactory();
 
 
     @Override

--- a/waltz-data/src/main/java/com/khartec/waltz/data/change_unit/ChangeUnitIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/change_unit/ChangeUnitIdSelectorFactory.java
@@ -29,8 +29,6 @@ import org.jooq.Condition;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.impl.DSL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.data.SelectorUtilities.ensureScopeIsExact;
@@ -38,17 +36,10 @@ import static com.khartec.waltz.schema.tables.ChangeUnit.CHANGE_UNIT;
 import static com.khartec.waltz.schema.tables.LogicalFlow.LOGICAL_FLOW;
 import static com.khartec.waltz.schema.tables.PhysicalFlow.PHYSICAL_FLOW;
 
-@Service
 public class ChangeUnitIdSelectorFactory implements IdSelectorFactory {
 
-    private final ApplicationIdSelectorFactory applicationIdSelectorFactory;
+    private final ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
 
-
-    @Autowired
-    public ChangeUnitIdSelectorFactory(ApplicationIdSelectorFactory applicationIdSelectorFactory) {
-        checkNotNull(applicationIdSelectorFactory, "applicationIdSelectorFactory cannot be null");
-        this.applicationIdSelectorFactory = applicationIdSelectorFactory;
-    }
 
 
     @Override

--- a/waltz-data/src/main/java/com/khartec/waltz/data/data_type/DataTypeIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/data_type/DataTypeIdSelectorFactory.java
@@ -23,19 +23,14 @@ package com.khartec.waltz.data.data_type;
 import com.khartec.waltz.data.entity_hierarchy.AbstractIdSelectorFactory;
 import com.khartec.waltz.model.EntityKind;
 import com.khartec.waltz.model.IdSelectionOptions;
-import org.jooq.DSLContext;
 import org.jooq.Record1;
 import org.jooq.Select;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
-@Service
 public class DataTypeIdSelectorFactory extends AbstractIdSelectorFactory {
 
 
-    @Autowired
-    public DataTypeIdSelectorFactory(DSLContext dsl) {
-        super(dsl, EntityKind.DATA_TYPE);
+    public DataTypeIdSelectorFactory() {
+        super(EntityKind.DATA_TYPE);
     }
 
     @Override

--- a/waltz-data/src/main/java/com/khartec/waltz/data/entity_hierarchy/AbstractIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/entity_hierarchy/AbstractIdSelectorFactory.java
@@ -23,7 +23,6 @@ import com.khartec.waltz.common.Checks;
 import com.khartec.waltz.data.IdSelectorFactory;
 import com.khartec.waltz.model.EntityKind;
 import com.khartec.waltz.model.IdSelectionOptions;
-import org.jooq.DSLContext;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.impl.DSL;
@@ -32,15 +31,11 @@ import static com.khartec.waltz.schema.tables.EntityHierarchy.ENTITY_HIERARCHY;
 
 public abstract class AbstractIdSelectorFactory implements IdSelectorFactory {
 
-    private final DSLContext dsl;
     private final EntityKind entityKind;
 
 
-    public AbstractIdSelectorFactory(DSLContext dsl, EntityKind entityKind) {
-        Checks.checkNotNull(dsl, "dsl cannot be null");
+    public AbstractIdSelectorFactory(EntityKind entityKind) {
         Checks.checkNotNull(entityKind, "entityKind cannot be null");
-
-        this.dsl = dsl;
         this.entityKind = entityKind;
     }
 

--- a/waltz-data/src/main/java/com/khartec/waltz/data/entity_hierarchy/EntityRootsSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/entity_hierarchy/EntityRootsSelectorFactory.java
@@ -21,36 +21,25 @@ package com.khartec.waltz.data.entity_hierarchy;
 
 import com.khartec.waltz.model.EntityKind;
 import com.khartec.waltz.schema.tables.EntityHierarchy;
-import org.jooq.DSLContext;
 import org.jooq.Record1;
 import org.jooq.Select;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import org.jooq.impl.DSL;
 
 import java.util.function.Function;
 
-import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.schema.tables.EntityHierarchy.ENTITY_HIERARCHY;
 
 
-@Service
 public class EntityRootsSelectorFactory implements Function<EntityKind, Select<Record1<Long>>> {
 
-    private final DSLContext dsl;
     private static final EntityHierarchy eh = ENTITY_HIERARCHY;
 
-
-    @Autowired
-    public EntityRootsSelectorFactory(DSLContext dsl) {
-        checkNotNull(dsl, "dsl cannot be null");
-
-        this.dsl = dsl;
-    }
 
 
     @Override
     public Select<Record1<Long>> apply(EntityKind entityKind) {
-        return dsl.select(eh.ID)
+        return DSL
+                .select(eh.ID)
                 .from(eh)
                 .where(eh.LEVEL.eq(1)
                         .and(eh.ID.eq(eh.ANCESTOR_ID)

--- a/waltz-data/src/main/java/com/khartec/waltz/data/flow_diagram/FlowDiagramIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/flow_diagram/FlowDiagramIdSelectorFactory.java
@@ -26,7 +26,6 @@ import com.khartec.waltz.model.IdSelectionOptions;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.impl.DSL;
-import org.springframework.stereotype.Service;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.data.SelectorUtilities.ensureScopeIsExact;
@@ -34,7 +33,6 @@ import static com.khartec.waltz.schema.tables.FlowDiagramEntity.FLOW_DIAGRAM_ENT
 import static com.khartec.waltz.schema.tables.PhysicalFlow.PHYSICAL_FLOW;
 
 
-@Service
 public class FlowDiagramIdSelectorFactory implements IdSelectorFactory {
 
     @Override

--- a/waltz-data/src/main/java/com/khartec/waltz/data/licence/LicenceIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/licence/LicenceIdSelectorFactory.java
@@ -23,25 +23,20 @@ import com.khartec.waltz.data.entity_hierarchy.AbstractIdSelectorFactory;
 import com.khartec.waltz.model.EntityKind;
 import com.khartec.waltz.model.EntityReference;
 import com.khartec.waltz.model.IdSelectionOptions;
-import org.jooq.DSLContext;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.impl.DSL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import static com.khartec.waltz.data.SelectorUtilities.ensureScopeIsExact;
 import static com.khartec.waltz.schema.tables.EntityRelationship.ENTITY_RELATIONSHIP;
 import static org.jooq.impl.DSL.selectDistinct;
 
 
-@Service
 public class LicenceIdSelectorFactory extends AbstractIdSelectorFactory {
 
 
-    @Autowired
-    public LicenceIdSelectorFactory(DSLContext dsl) {
-        super(dsl, EntityKind.LICENCE);
+    public LicenceIdSelectorFactory() {
+        super(EntityKind.LICENCE);
     }
 
 

--- a/waltz-data/src/main/java/com/khartec/waltz/data/logical_data_element/LogicalDataElementIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/logical_data_element/LogicalDataElementIdSelectorFactory.java
@@ -26,8 +26,6 @@ import com.khartec.waltz.model.ImmutableIdSelectionOptions;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.impl.DSL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.common.Checks.checkTrue;
@@ -37,16 +35,9 @@ import static com.khartec.waltz.schema.tables.PhysicalSpecDefn.PHYSICAL_SPEC_DEF
 import static com.khartec.waltz.schema.tables.PhysicalSpecDefnField.PHYSICAL_SPEC_DEFN_FIELD;
 
 
-@Service
 public class LogicalDataElementIdSelectorFactory implements IdSelectorFactory {
 
-    private final DataTypeIdSelectorFactory dataTypeIdSelectorFactory;
-
-
-    @Autowired
-    public LogicalDataElementIdSelectorFactory(DataTypeIdSelectorFactory dataTypeIdSelectorFactory) {
-        this.dataTypeIdSelectorFactory = dataTypeIdSelectorFactory;
-    }
+    private final DataTypeIdSelectorFactory dataTypeIdSelectorFactory = new DataTypeIdSelectorFactory();
 
 
     @Override

--- a/waltz-data/src/main/java/com/khartec/waltz/data/logical_flow/LogicalFlowIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/logical_flow/LogicalFlowIdSelectorFactory.java
@@ -31,8 +31,6 @@ import org.jooq.Condition;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.impl.DSL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.common.SetUtilities.map;
@@ -44,29 +42,17 @@ import static com.khartec.waltz.schema.tables.LogicalFlow.LOGICAL_FLOW;
 import static com.khartec.waltz.schema.tables.LogicalFlowDecorator.LOGICAL_FLOW_DECORATOR;
 import static com.khartec.waltz.schema.tables.PhysicalFlow.PHYSICAL_FLOW;
 import static com.khartec.waltz.schema.tables.PhysicalFlowParticipant.PHYSICAL_FLOW_PARTICIPANT;
-import static com.khartec.waltz.schema.tables.PhysicalSpecification.PHYSICAL_SPECIFICATION;
 
 
-@Service
 public class LogicalFlowIdSelectorFactory implements IdSelectorFactory {
 
 
-    private final ApplicationIdSelectorFactory applicationIdSelectorFactory;
-    private final DataTypeIdSelectorFactory dataTypeIdSelectorFactory;
+    private final ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
+    private final DataTypeIdSelectorFactory dataTypeIdSelectorFactory = new DataTypeIdSelectorFactory();
 
     private final static Application CONSUMER_APP = APPLICATION.as("consumer");
     private final static Application SUPPLIER_APP = APPLICATION.as("supplier");
 
-
-    @Autowired
-    public LogicalFlowIdSelectorFactory(ApplicationIdSelectorFactory applicationIdSelectorFactory,
-                                        DataTypeIdSelectorFactory dataTypeIdSelectorFactory) {
-        checkNotNull(applicationIdSelectorFactory, "applicationIdSelectorFactory cannot be null");
-        checkNotNull(dataTypeIdSelectorFactory, "dataTypeIdSelectorFactory cannot be null");
-
-        this.applicationIdSelectorFactory = applicationIdSelectorFactory;
-        this.dataTypeIdSelectorFactory = dataTypeIdSelectorFactory;
-    }
 
 
     @Override

--- a/waltz-data/src/main/java/com/khartec/waltz/data/measurable/MeasurableIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/measurable/MeasurableIdSelectorFactory.java
@@ -21,6 +21,7 @@ package com.khartec.waltz.data.measurable;
 
 
 import com.khartec.waltz.data.IdSelectorFactory;
+import com.khartec.waltz.data.application.ApplicationIdSelectorFactory;
 import com.khartec.waltz.data.orgunit.OrganisationalUnitIdSelectorFactory;
 import com.khartec.waltz.model.EntityKind;
 import com.khartec.waltz.model.HierarchyQueryScope;
@@ -28,35 +29,20 @@ import com.khartec.waltz.model.IdSelectionOptions;
 import com.khartec.waltz.model.application.ApplicationIdSelectionOptions;
 import org.jooq.*;
 import org.jooq.impl.DSL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
-import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.common.Checks.checkTrue;
 import static com.khartec.waltz.data.SelectorUtilities.ensureScopeIsExact;
 import static com.khartec.waltz.data.SelectorUtilities.mkApplicationConditions;
 import static com.khartec.waltz.schema.Tables.*;
 import static com.khartec.waltz.schema.tables.Application.APPLICATION;
-import static com.khartec.waltz.schema.tables.ApplicationGroupEntry.APPLICATION_GROUP_ENTRY;
 import static com.khartec.waltz.schema.tables.EntityHierarchy.ENTITY_HIERARCHY;
 import static com.khartec.waltz.schema.tables.Measurable.MEASURABLE;
 import static com.khartec.waltz.schema.tables.MeasurableRating.MEASURABLE_RATING;
 import static java.lang.String.format;
 
-@Service
 public class MeasurableIdSelectorFactory implements IdSelectorFactory {
 
-    private final OrganisationalUnitIdSelectorFactory orgUnitIdSelectorFactory;
-    private final DSLContext dsl;
-
-    @Autowired
-    public MeasurableIdSelectorFactory(DSLContext dsl, 
-                                       OrganisationalUnitIdSelectorFactory orgUnitIdSelectorFactory) {
-        checkNotNull(orgUnitIdSelectorFactory, "orgUnitIdSelectorFactory cannot be null");
-        checkNotNull(dsl, "dsl cannot be null");
-        this.dsl = dsl;
-        this.orgUnitIdSelectorFactory = orgUnitIdSelectorFactory;
-    }
+    private final OrganisationalUnitIdSelectorFactory orgUnitIdSelectorFactory = new OrganisationalUnitIdSelectorFactory();
 
 
     @Override
@@ -104,7 +90,7 @@ public class MeasurableIdSelectorFactory implements IdSelectorFactory {
 
     private Select<Record1<Long>> mkForPersonReportees(ApplicationIdSelectionOptions options) {
 
-        Select<Record1<String>> emp = dsl.select(PERSON.EMPLOYEE_ID)
+        Select<Record1<String>> emp = DSL.select(PERSON.EMPLOYEE_ID)
                 .from(PERSON)
                 .where(PERSON.ID.eq(options.entityReference().id()));
 
@@ -156,13 +142,8 @@ public class MeasurableIdSelectorFactory implements IdSelectorFactory {
 
     private Select<Record1<Long>> mkForAppGroup(ApplicationIdSelectionOptions options) {
         checkTrue(options.scope() == HierarchyQueryScope.EXACT, "Can only calculate app-group based selectors with exact scopes");
-        SelectConditionStep<Record1<Long>> validAppIdsInGroup = DSL
-                .select(APPLICATION_GROUP_ENTRY.APPLICATION_ID)
-                .from(APPLICATION_GROUP_ENTRY)
-                .innerJoin(APPLICATION)
-                .on(APPLICATION.ID.eq(APPLICATION_GROUP_ENTRY.APPLICATION_ID))
-                .where(mkApplicationConditions(options)
-                        .and(APPLICATION_GROUP_ENTRY.GROUP_ID.eq(options.entityReference().id())));
+
+        Select<Record1<Long>> validAppIdsInGroup = ApplicationIdSelectorFactory.mkForAppGroup(options);
 
         SelectConditionStep<Record1<Long>> measurableIdsUsedByGroup = DSL
                 .selectDistinct(MEASURABLE_RATING.MEASURABLE_ID)

--- a/waltz-data/src/main/java/com/khartec/waltz/data/orgunit/OrganisationalUnitIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/orgunit/OrganisationalUnitIdSelectorFactory.java
@@ -23,19 +23,14 @@ package com.khartec.waltz.data.orgunit;
 import com.khartec.waltz.data.entity_hierarchy.AbstractIdSelectorFactory;
 import com.khartec.waltz.model.EntityKind;
 import com.khartec.waltz.model.IdSelectionOptions;
-import org.jooq.DSLContext;
 import org.jooq.Record1;
 import org.jooq.Select;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
-@Service
 public class OrganisationalUnitIdSelectorFactory extends AbstractIdSelectorFactory {
 
 
-    @Autowired
-    public OrganisationalUnitIdSelectorFactory(DSLContext dsl) {
-        super(dsl, EntityKind.ORG_UNIT);
+    public OrganisationalUnitIdSelectorFactory() {
+        super(EntityKind.ORG_UNIT);
     }
 
     @Override

--- a/waltz-data/src/main/java/com/khartec/waltz/data/physical_flow/PhysicalFlowIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/physical_flow/PhysicalFlowIdSelectorFactory.java
@@ -27,7 +27,6 @@ import org.jooq.Condition;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.impl.DSL;
-import org.springframework.stereotype.Service;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.data.SelectorUtilities.ensureScopeIsExact;
@@ -36,7 +35,6 @@ import static com.khartec.waltz.schema.tables.PhysicalFlow.PHYSICAL_FLOW;
 import static com.khartec.waltz.schema.tables.PhysicalFlowParticipant.PHYSICAL_FLOW_PARTICIPANT;
 
 
-@Service
 public class PhysicalFlowIdSelectorFactory implements IdSelectorFactory {
 
     @Override

--- a/waltz-data/src/main/java/com/khartec/waltz/data/physical_specification/PhysicalSpecificationIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/physical_specification/PhysicalSpecificationIdSelectorFactory.java
@@ -28,8 +28,6 @@ import org.jooq.Condition;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.impl.DSL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.data.SelectorUtilities.ensureScopeIsExact;
@@ -40,17 +38,9 @@ import static com.khartec.waltz.schema.tables.PhysicalSpecDefnField.PHYSICAL_SPE
 import static com.khartec.waltz.schema.tables.PhysicalSpecification.PHYSICAL_SPECIFICATION;
 
 
-@Service
 public class PhysicalSpecificationIdSelectorFactory implements IdSelectorFactory {
 
-    private final PhysicalFlowIdSelectorFactory physicalFlowIdSelectorFactory;
-
-
-    @Autowired
-    public PhysicalSpecificationIdSelectorFactory(PhysicalFlowIdSelectorFactory physicalFlowIdSelectorFactory) {
-        checkNotNull(physicalFlowIdSelectorFactory, "physicalFlowIdSelectorFactory cannot be null");
-        this.physicalFlowIdSelectorFactory = physicalFlowIdSelectorFactory;
-    }
+    private final PhysicalFlowIdSelectorFactory physicalFlowIdSelectorFactory = new PhysicalFlowIdSelectorFactory();
 
 
     @Override

--- a/waltz-data/src/main/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefnFieldIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefnFieldIdSelectorFactory.java
@@ -24,21 +24,13 @@ import com.khartec.waltz.model.IdSelectionOptions;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.impl.DSL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.data.SelectorUtilities.ensureScopeIsExact;
 import static com.khartec.waltz.schema.tables.PhysicalSpecDefnField.PHYSICAL_SPEC_DEFN_FIELD;
 
 
-@Service
 public class PhysicalSpecDefnFieldIdSelectorFactory implements IdSelectorFactory {
-
-    @Autowired
-    public PhysicalSpecDefnFieldIdSelectorFactory() {
-    }
-
 
     @Override
     public Select<Record1<Long>> apply(IdSelectionOptions options) {

--- a/waltz-data/src/main/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefnIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefnIdSelectorFactory.java
@@ -24,8 +24,6 @@ import com.khartec.waltz.model.IdSelectionOptions;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.impl.DSL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.data.SelectorUtilities.ensureScopeIsExact;
@@ -33,13 +31,7 @@ import static com.khartec.waltz.schema.tables.PhysicalSpecDefn.PHYSICAL_SPEC_DEF
 import static com.khartec.waltz.schema.tables.PhysicalSpecDefnField.PHYSICAL_SPEC_DEFN_FIELD;
 
 
-@Service
 public class PhysicalSpecDefnIdSelectorFactory implements IdSelectorFactory {
-
-    @Autowired
-    public PhysicalSpecDefnIdSelectorFactory() {
-    }
-
 
     @Override
     public Select<Record1<Long>> apply(IdSelectionOptions options) {
@@ -58,7 +50,8 @@ public class PhysicalSpecDefnIdSelectorFactory implements IdSelectorFactory {
     private Select<Record1<Long>> mkForLogicalElement(IdSelectionOptions options) {
         ensureScopeIsExact(options);
         long logicalElementId = options.entityReference().id();
-        return DSL.select(PHYSICAL_SPEC_DEFN.ID)
+        return DSL
+                .select(PHYSICAL_SPEC_DEFN.ID)
                 .from(PHYSICAL_SPEC_DEFN)
                 .join(PHYSICAL_SPEC_DEFN_FIELD).on(PHYSICAL_SPEC_DEFN_FIELD.SPEC_DEFN_ID.eq(PHYSICAL_SPEC_DEFN.ID))
                 .where(PHYSICAL_SPEC_DEFN_FIELD.LOGICAL_DATA_ELEMENT_ID.eq(logicalElementId));

--- a/waltz-data/src/main/java/com/khartec/waltz/data/roadmap/RoadmapIdSelectorFactory.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/roadmap/RoadmapIdSelectorFactory.java
@@ -6,8 +6,6 @@ import com.khartec.waltz.model.EntityReference;
 import com.khartec.waltz.model.IdSelectionOptions;
 import org.jooq.Record1;
 import org.jooq.Select;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import static com.khartec.waltz.schema.tables.EntityRelationship.ENTITY_RELATIONSHIP;
 import static org.jooq.impl.DSL.selectDistinct;
@@ -22,13 +20,7 @@ import static org.jooq.impl.DSL.selectDistinct;
  *
  *  Note, currently, this selector factory only supports the first of these options.
  */
-@Service
 public class RoadmapIdSelectorFactory implements IdSelectorFactory {
-
-
-    @Autowired
-    public RoadmapIdSelectorFactory() {
-    }
 
 
     @Override

--- a/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/ApplicationIdSelectorHarness.java
+++ b/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/ApplicationIdSelectorHarness.java
@@ -42,13 +42,13 @@ public class ApplicationIdSelectorHarness {
     public static void main(String[] args) {
 
         AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(DIConfiguration.class);
-        ApplicationIdSelectorFactory factory = ctx.getBean(ApplicationIdSelectorFactory.class);
+        ApplicationIdSelectorFactory factory = new ApplicationIdSelectorFactory();
         DSLContext dsl = ctx.getBean(DSLContext.class);
 
         ApplicationService applicationService = ctx.getBean(ApplicationService.class);
 
         ApplicationIdSelectionOptions options = ApplicationIdSelectionOptions.mkOpts(
-                EntityReference.mkRef(EntityKind.APP_GROUP, 8L),
+                EntityReference.mkRef(EntityKind.APP_GROUP, 11309L),
                 HierarchyQueryScope.EXACT);
 
 

--- a/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/AssetCostHarness.java
+++ b/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/AssetCostHarness.java
@@ -44,7 +44,7 @@ public class AssetCostHarness {
         AssetCostService service = ctx.getBean(AssetCostService.class);
         AssetCostStatsDao statsDao = ctx.getBean(AssetCostStatsDao.class);
         AssetCostDao costDao = ctx.getBean(AssetCostDao.class);
-        ApplicationIdSelectorFactory selectorFactory = ctx.getBean(ApplicationIdSelectorFactory.class);
+        ApplicationIdSelectorFactory selectorFactory = new ApplicationIdSelectorFactory();
 
 
         long st = System.currentTimeMillis();

--- a/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/ChangeInitiativeHarness.java
+++ b/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/ChangeInitiativeHarness.java
@@ -39,7 +39,7 @@ public class ChangeInitiativeHarness {
         AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(DIConfiguration.class);
 
         ChangeInitiativeDao dao = ctx.getBean(ChangeInitiativeDao.class);
-        ChangeInitiativeIdSelectorFactory selectorFactory = ctx.getBean(ChangeInitiativeIdSelectorFactory.class);
+        ChangeInitiativeIdSelectorFactory selectorFactory = new ChangeInitiativeIdSelectorFactory();
 
         IdSelectionOptions opts = mkOpts(
                 mkRef(EntityKind.APPLICATION, 40),

--- a/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/DataExtractHarness.java
+++ b/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/DataExtractHarness.java
@@ -58,7 +58,7 @@ public class DataExtractHarness {
 
         AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(DIConfiguration.class);
         DSLContext dsl = ctx.getBean(DSLContext.class);
-        LogicalFlowIdSelectorFactory logicalFlowIdSelectorFactory = ctx.getBean(LogicalFlowIdSelectorFactory.class);
+        LogicalFlowIdSelectorFactory logicalFlowIdSelectorFactory = new LogicalFlowIdSelectorFactory();
 
         IdSelectionOptions options = IdSelectionOptions.mkOpts(
                 EntityReference.mkRef(EntityKind.ORG_UNIT, 4326),

--- a/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/DataFlowHarness.java
+++ b/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/DataFlowHarness.java
@@ -46,7 +46,7 @@ public class DataFlowHarness {
         DSLContext dsl = ctx.getBean(DSLContext.class);
         LogicalFlowService service = ctx.getBean(LogicalFlowService.class);
         LogicalFlowDao dao = ctx.getBean(LogicalFlowDao.class);
-        LogicalFlowIdSelectorFactory factory = ctx.getBean(LogicalFlowIdSelectorFactory.class);
+        LogicalFlowIdSelectorFactory factory = new LogicalFlowIdSelectorFactory();
 
         IdSelectionOptions options = IdSelectionOptions.mkOpts(
                 EntityReference.mkRef(EntityKind.ORG_UNIT, 5000),

--- a/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/LogicalFlowHarness.java
+++ b/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/LogicalFlowHarness.java
@@ -43,7 +43,7 @@ public class LogicalFlowHarness {
         DSLContext dsl = ctx.getBean(DSLContext.class);
         LogicalFlowDao dao = ctx.getBean(LogicalFlowDao.class);
         LogicalFlowService service = ctx.getBean(LogicalFlowService.class);
-        ApplicationIdSelectorFactory factory = ctx.getBean(ApplicationIdSelectorFactory.class);
+        ApplicationIdSelectorFactory factory = new ApplicationIdSelectorFactory();
 
         IdSelectionOptions options = IdSelectionOptions.mkOpts(
                 mkRef(EntityKind.PERSON, 262508),

--- a/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/MeasurableHarness.java
+++ b/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/MeasurableHarness.java
@@ -44,7 +44,7 @@ public class MeasurableHarness {
 
         AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(DIConfiguration.class);
 
-        MeasurableIdSelectorFactory factory = ctx.getBean(MeasurableIdSelectorFactory.class);
+        MeasurableIdSelectorFactory factory = new MeasurableIdSelectorFactory();
         MeasurableService measurableService = ctx.getBean(MeasurableService.class);
 
         EntityReference ref = mkRef(

--- a/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/MeasurableRatingExporterHarness.java
+++ b/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/MeasurableRatingExporterHarness.java
@@ -30,7 +30,6 @@ import org.jooq.Select;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import static com.khartec.waltz.model.EntityReference.mkRef;
-import static com.khartec.waltz.model.IdSelectionOptions.mkOpts;
 
 public class MeasurableRatingExporterHarness {
 
@@ -38,7 +37,7 @@ public class MeasurableRatingExporterHarness {
         AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(DIConfiguration.class);
         DSLContext dsl = ctx.getBean(DSLContext.class);
 
-        ApplicationIdSelectorFactory applicationIdSelectorFactory = ctx.getBean(ApplicationIdSelectorFactory.class);
+        ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
 
         Select<Record1<Long>> appSelector = applicationIdSelectorFactory.apply(ApplicationIdSelectionOptions.mkOpts(
                 mkRef(EntityKind.ORG_UNIT, 10L),

--- a/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/MeasurableRatingHarness.java
+++ b/waltz-jobs/src/main/java/com/khartec/waltz/jobs/harness/MeasurableRatingHarness.java
@@ -45,7 +45,7 @@ public class MeasurableRatingHarness {
         AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(DIConfiguration.class);
 
         MeasurableRatingDao measurableRatingDao = ctx.getBean(MeasurableRatingDao.class);
-        MeasurableIdSelectorFactory measurableIdSelectorFactory = ctx.getBean(MeasurableIdSelectorFactory.class);
+        MeasurableIdSelectorFactory measurableIdSelectorFactory = new MeasurableIdSelectorFactory();
 
         EntityReference direct = mkRef(MEASURABLE, 18310);
         EntityReference indirect = mkRef(MEASURABLE, 18064);

--- a/waltz-jobs/src/main/java/com/khartec/waltz/jobs/tools/ChangeReporter.java
+++ b/waltz-jobs/src/main/java/com/khartec/waltz/jobs/tools/ChangeReporter.java
@@ -48,7 +48,7 @@ public class ChangeReporter {
     public static void main(String[] args) throws IOException {
         AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(DIConfiguration.class);
         DSLContext dsl = ctx.getBean(DSLContext.class);
-        ApplicationIdSelectorFactory selectorFactory = ctx.getBean(ApplicationIdSelectorFactory.class);
+        ApplicationIdSelectorFactory selectorFactory = new ApplicationIdSelectorFactory();
 
         LocalDateTime exerciseStart = LocalDateTime.of(2018, 06, 04, 0, 1).truncatedTo(ChronoUnit.DAYS);
         LocalDateTime dayBeforeYesterday = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).minusDays(1);

--- a/waltz-jobs/src/main/java/com/khartec/waltz/jobs/tools/FlowSummaryWithTypesAndPhysicalsExport.java
+++ b/waltz-jobs/src/main/java/com/khartec/waltz/jobs/tools/FlowSummaryWithTypesAndPhysicalsExport.java
@@ -74,7 +74,7 @@ public class FlowSummaryWithTypesAndPhysicalsExport {
     public static void main(String[] args) throws IOException {
         AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(DIConfiguration.class);
         DSLContext dsl = ctx.getBean(DSLContext.class);
-        ApplicationIdSelectorFactory appIdSelectorFactory = ctx.getBean(ApplicationIdSelectorFactory.class);
+        ApplicationIdSelectorFactory appIdSelectorFactory = new ApplicationIdSelectorFactory();
         ApplicationDao applicationDao = ctx.getBean(ApplicationDao.class);
         OrganisationalUnitDao organisationalUnitDao = ctx.getBean(OrganisationalUnitDao.class);
         LogicalFlowDao logicalFlowDao = ctx.getBean(LogicalFlowDao.class);

--- a/waltz-jobs/src/main/java/com/khartec/waltz/jobs/tools/RemoveTaxonomy.java
+++ b/waltz-jobs/src/main/java/com/khartec/waltz/jobs/tools/RemoveTaxonomy.java
@@ -67,7 +67,7 @@ public class RemoveTaxonomy {
                 return;
             }
 
-            MeasurableIdSelectorFactory selectorFactory = ctx.getBean(MeasurableIdSelectorFactory.class);
+            MeasurableIdSelectorFactory selectorFactory = new MeasurableIdSelectorFactory();
             Select<Record1<Long>> measurableIdSelector = selectorFactory
                     .apply(mkOpts(
                         mkRef(EntityKind.MEASURABLE_CATEGORY, categoryId),

--- a/waltz-service/src/main/java/com/khartec/waltz/service/application/ApplicationService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/application/ApplicationService.java
@@ -55,26 +55,23 @@ public class ApplicationService {
     private final EntityTagDao entityTagDao;
     private final EntityAliasDao entityAliasDao;
     private final ApplicationSearchDao appSearchDao;
-    private final ApplicationIdSelectorFactory appIdSelectorFactory;
+    private final ApplicationIdSelectorFactory appIdSelectorFactory = new ApplicationIdSelectorFactory();
 
 
     @Autowired
     public ApplicationService(ApplicationDao appDao,
                               EntityTagDao entityTagDao,
                               EntityAliasDao entityAliasDao,
-                              ApplicationSearchDao appSearchDao,
-                              ApplicationIdSelectorFactory appIdSelectorFactory) {
+                              ApplicationSearchDao appSearchDao) {
         checkNotNull(appDao, "appDao must not be null");
         checkNotNull(entityTagDao, "entityTagDao must not be null");
         checkNotNull(entityAliasDao, "entityAliasDao must not be null");
         checkNotNull(appSearchDao, "appSearchDao must not be null");
-        checkNotNull(appIdSelectorFactory, "appIdSelectorFactory cannot be null");
 
         this.applicationDao = appDao;
         this.entityTagDao = entityTagDao;
         this.entityAliasDao = entityAliasDao;
         this.appSearchDao = appSearchDao;
-        this.appIdSelectorFactory = appIdSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/assessment_rating/AssessmentRatingService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/assessment_rating/AssessmentRatingService.java
@@ -48,25 +48,22 @@ public class AssessmentRatingService {
     private final AssessmentDefinitionDao assessmentDefinitionDao;
     private final RatingSchemeDAO ratingSchemeDAO;
     private final ChangeLogService changeLogService;
-    private final GenericSelectorFactory genericSelectorFactory;
+    private final GenericSelectorFactory genericSelectorFactory = new GenericSelectorFactory();
 
     @Autowired
     public AssessmentRatingService(
             AssessmentRatingDao assessmentRatingDao,
             AssessmentDefinitionDao assessmentDefinitionDao,
             RatingSchemeDAO ratingSchemeDAO,
-            GenericSelectorFactory genericSelectorFactory,
             ChangeLogService changeLogService) {
         checkNotNull(assessmentRatingDao, "assessmentRatingDao cannot be null");
         checkNotNull(assessmentDefinitionDao, "assessmentDefinitionDao cannot be null");
         checkNotNull(ratingSchemeDAO, "ratingSchemeDao cannot be null");
-        checkNotNull(genericSelectorFactory, "genericSelectorFactory cannot be null");
         checkNotNull(changeLogService, "changeLogService cannot be null");
 
         this.assessmentRatingDao = assessmentRatingDao;
         this.ratingSchemeDAO = ratingSchemeDAO;
         this.assessmentDefinitionDao = assessmentDefinitionDao;
-        this.genericSelectorFactory = genericSelectorFactory;
         this.changeLogService = changeLogService;
 
     }

--- a/waltz-service/src/main/java/com/khartec/waltz/service/asset_cost/AssetCostService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/asset_cost/AssetCostService.java
@@ -44,20 +44,17 @@ public class AssetCostService {
 
     private final AssetCostDao assetCostDao;
     private final AssetCostStatsDao assetCostStatsDao;
-    private final ApplicationIdSelectorFactory idSelectorFactory;
+    private final ApplicationIdSelectorFactory idSelectorFactory = new ApplicationIdSelectorFactory();
 
 
     @Autowired
     public AssetCostService(AssetCostDao assetCodeDao,
-                            AssetCostStatsDao assetCostStatsDao,
-                            ApplicationIdSelectorFactory idSelectorFactory) {
+                            AssetCostStatsDao assetCostStatsDao) {
         checkNotNull(assetCodeDao, "assetCodeDao cannot be null");
         checkNotNull(assetCostStatsDao, "assetCostStatsDao cannot be null");
-        checkNotNull(idSelectorFactory, "idSelectorFactory cannot be null");
 
         this.assetCostDao = assetCodeDao;
         this.assetCostStatsDao = assetCostStatsDao;
-        this.idSelectorFactory = idSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/attestation/AttestationRunService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/attestation/AttestationRunService.java
@@ -22,7 +22,6 @@ package com.khartec.waltz.service.attestation;
 
 import com.khartec.waltz.data.GenericSelector;
 import com.khartec.waltz.data.GenericSelectorFactory;
-import com.khartec.waltz.data.IdSelectorFactory;
 import com.khartec.waltz.data.attestation.AttestationInstanceDao;
 import com.khartec.waltz.data.attestation.AttestationInstanceRecipientDao;
 import com.khartec.waltz.data.attestation.AttestationRunDao;
@@ -36,7 +35,10 @@ import org.jooq.Select;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.model.EntityReference.mkRef;
@@ -50,7 +52,7 @@ public class AttestationRunService {
     private final AttestationInstanceRecipientDao attestationInstanceRecipientDao;
     private final AttestationRunDao attestationRunDao;
     private final EmailService emailService;
-    private final GenericSelectorFactory genericSelectorFactory;
+    private final GenericSelectorFactory genericSelectorFactory = new GenericSelectorFactory();
     private final InvolvementDao involvementDao;
 
     @Autowired
@@ -58,20 +60,17 @@ public class AttestationRunService {
                                  AttestationInstanceRecipientDao attestationInstanceRecipientDao,
                                  AttestationRunDao attestationRunDao,
                                  EmailService emailService,
-                                 GenericSelectorFactory genericSelectorFactory,
                                  InvolvementDao involvementDao) {
         checkNotNull(attestationInstanceRecipientDao, "attestationInstanceRecipientDao cannot be null");
         checkNotNull(attestationInstanceDao, "attestationInstanceDao cannot be null");
         checkNotNull(attestationRunDao, "attestationRunDao cannot be null");
         checkNotNull(emailService, "emailService cannot be null");
-        checkNotNull(genericSelectorFactory, "genericSelectorFactory cannot be null");
         checkNotNull(involvementDao, "involvementDao cannot be null");
 
         this.attestationInstanceDao = attestationInstanceDao;
         this.attestationInstanceRecipientDao = attestationInstanceRecipientDao;
         this.attestationRunDao = attestationRunDao;
         this.emailService = emailService;
-        this.genericSelectorFactory = genericSelectorFactory;
         this.involvementDao = involvementDao;
     }
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/authoritative_source/AuthSourceRatingCalculator.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/authoritative_source/AuthSourceRatingCalculator.java
@@ -51,25 +51,22 @@ public class AuthSourceRatingCalculator {
     private static final Logger LOG = LoggerFactory.getLogger(AuthSourceRatingCalculator.class);
 
     private final DataTypeDao dataTypeDao;
-    private final ApplicationIdSelectorFactory appIdSelectorFactory;
+    private final ApplicationIdSelectorFactory appIdSelectorFactory = new ApplicationIdSelectorFactory();
     private final LogicalFlowDecoratorDao logicalFlowDecoratorDao;
     private final LogicalFlowDecoratorRatingsCalculator ratingsCalculator;
 
 
     @Autowired
     public AuthSourceRatingCalculator(DataTypeDao dataTypeDao,
-                                      ApplicationIdSelectorFactory appIdSelectorFactory,
                                       LogicalFlowDecoratorRatingsCalculator ratingsCalculator,
                                       LogicalFlowDecoratorDao logicalFlowDecoratorDao) {
 
         checkNotNull(dataTypeDao, "dataTypeDao cannot be null");
-        checkNotNull(appIdSelectorFactory, "appIdSelectorFactory cannot be null");
         checkNotNull(ratingsCalculator, "ratingsCalculator cannot be null");
         checkNotNull(logicalFlowDecoratorDao, "logicalFlowDecoratorDao cannot be null");
 
         this.dataTypeDao = dataTypeDao;
         this.logicalFlowDecoratorDao = logicalFlowDecoratorDao;
-        this.appIdSelectorFactory = appIdSelectorFactory;
         this.ratingsCalculator = ratingsCalculator;
     }
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/authoritative_source/AuthoritativeSourceService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/authoritative_source/AuthoritativeSourceService.java
@@ -28,7 +28,6 @@ import com.khartec.waltz.data.data_flow_decorator.LogicalFlowDecoratorDao;
 import com.khartec.waltz.data.data_type.DataTypeDao;
 import com.khartec.waltz.data.data_type.DataTypeIdSelectorFactory;
 import com.khartec.waltz.data.orgunit.OrganisationalUnitDao;
-import com.khartec.waltz.data.orgunit.OrganisationalUnitIdSelectorFactory;
 import com.khartec.waltz.model.*;
 import com.khartec.waltz.model.application.Application;
 import com.khartec.waltz.model.application.ApplicationIdSelectionOptions;
@@ -74,12 +73,11 @@ public class AuthoritativeSourceService {
     private final OrganisationalUnitDao organisationalUnitDao;
     private final ApplicationDao applicationDao;
     private final AuthSourceRatingCalculator ratingCalculator;
-    private final DataTypeIdSelectorFactory dataTypeIdSelectorFactory;
-    private final OrganisationalUnitIdSelectorFactory organisationalUnitIdSelectorFactory;
     private final ChangeLogService changeLogService;
-    private final ApplicationIdSelectorFactory applicationIdSelectorFactory;
     private final LogicalFlowDecoratorDao logicalFlowDecoratorDao;
-    private final GenericSelectorFactory genericSelectorFactory;
+    private final DataTypeIdSelectorFactory dataTypeIdSelectorFactory = new DataTypeIdSelectorFactory();
+    private final ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
+    private final GenericSelectorFactory genericSelectorFactory = new GenericSelectorFactory();
 
 
     @Autowired
@@ -88,21 +86,13 @@ public class AuthoritativeSourceService {
                                       OrganisationalUnitDao organisationalUnitDao,
                                       ApplicationDao applicationDao,
                                       AuthSourceRatingCalculator ratingCalculator,
-                                      ApplicationIdSelectorFactory applicationIdSelectorFactory,
-                                      DataTypeIdSelectorFactory dataTypeIdSelectorFactory,
-                                      GenericSelectorFactory genericSelectorFactory,
-                                      OrganisationalUnitIdSelectorFactory organisationalUnitIdSelectorFactory,
-                                      ChangeLogService changeLogService, 
+                                      ChangeLogService changeLogService,
                                       LogicalFlowDecoratorDao logicalFlowDecoratorDao) {
         checkNotNull(authoritativeSourceDao, "authoritativeSourceDao must not be null");
         checkNotNull(dataTypeDao, "dataTypeDao cannot be null");
         checkNotNull(organisationalUnitDao, "organisationalUnitDao cannot be null");
         checkNotNull(applicationDao, "applicationDao cannot be null");
         checkNotNull(ratingCalculator, "ratingCalculator cannot be null");
-        checkNotNull(applicationIdSelectorFactory, "applicationIdSelectorFactory cannot be null");
-        checkNotNull(dataTypeIdSelectorFactory, "dataTypeIdSelectorFactory cannot be null");
-        checkNotNull(genericSelectorFactory, "genericSelectorFactory cannot be null");
-        checkNotNull(organisationalUnitIdSelectorFactory, "organisationalUnitIdSelectorFactory cannot be null");
         checkNotNull(changeLogService, "changeLogService cannot be null");
         checkNotNull(logicalFlowDecoratorDao, "logicalFlowDecoratorDao cannot be null");
 
@@ -111,10 +101,6 @@ public class AuthoritativeSourceService {
         this.organisationalUnitDao = organisationalUnitDao;
         this.applicationDao = applicationDao;
         this.ratingCalculator = ratingCalculator;
-        this.applicationIdSelectorFactory = applicationIdSelectorFactory;
-        this.dataTypeIdSelectorFactory = dataTypeIdSelectorFactory;
-        this.genericSelectorFactory = genericSelectorFactory;
-        this.organisationalUnitIdSelectorFactory = organisationalUnitIdSelectorFactory;
         this.changeLogService = changeLogService;
         this.logicalFlowDecoratorDao = logicalFlowDecoratorDao;
     }

--- a/waltz-service/src/main/java/com/khartec/waltz/service/bookmark/BookmarkService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/bookmark/BookmarkService.java
@@ -41,22 +41,16 @@ public class BookmarkService {
 
     private final BookmarkDao bookmarkDao;
     private final ChangeLogService changeLogService;
-    private final BookmarkIdSelectorFactory bookmarkIdSelectorFactory;
-    private final GenericSelectorFactory genericSelectorFactory;
+    private final BookmarkIdSelectorFactory bookmarkIdSelectorFactory = new BookmarkIdSelectorFactory();
+    private final GenericSelectorFactory genericSelectorFactory = new GenericSelectorFactory();
 
 
     @Autowired
     public BookmarkService(BookmarkDao bookmarkDao,
-                           BookmarkIdSelectorFactory bookmarkIdSelectorFactory,
-                           GenericSelectorFactory genericSelectorFactory,
                            ChangeLogService changeLogService) {
         checkNotNull(bookmarkDao, "bookmarkDao must not be null");
-        checkNotNull(bookmarkIdSelectorFactory, "bookmarkIdSelectorFactory cannot be null");
-        checkNotNull(genericSelectorFactory, "genericSelectorFactory cannot be null");
         checkNotNull(changeLogService, "changeLogService cannot be null");
         this.bookmarkDao = bookmarkDao;
-        this.bookmarkIdSelectorFactory = bookmarkIdSelectorFactory;
-        this.genericSelectorFactory = genericSelectorFactory;
         this.changeLogService = changeLogService;
     }
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/change_initiative/ChangeInitiativeService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/change_initiative/ChangeInitiativeService.java
@@ -51,26 +51,22 @@ public class ChangeInitiativeService {
     private final ChangeInitiativeSearchDao searchDao;
     private final EntityRelationshipDao relationshipDao;
     private final ChangeLogService changeLogService;
-    private final ChangeInitiativeIdSelectorFactory changeInitiativeIdSelectorFactory;
+    private final ChangeInitiativeIdSelectorFactory changeInitiativeIdSelectorFactory = new ChangeInitiativeIdSelectorFactory();
 
     @Autowired
-    public ChangeInitiativeService(
-            ChangeInitiativeDao changeInitiativeDao,
-            ChangeInitiativeSearchDao searchDao,
-            EntityRelationshipDao relationshipDao,
-            ChangeInitiativeIdSelectorFactory changeInitiativeIdSelectorFactory,
-            ChangeLogService changeLogService) {
-
+    public ChangeInitiativeService(ChangeInitiativeDao changeInitiativeDao,
+                                   ChangeInitiativeSearchDao searchDao,
+                                   EntityRelationshipDao relationshipDao,
+                                   ChangeLogService changeLogService)
+    {
         checkNotNull(changeInitiativeDao, "changeInitiativeDao cannot be null");
         checkNotNull(searchDao, "searchDao cannot be null");
         checkNotNull(relationshipDao, "relationshipDao cannot be null");
-        checkNotNull(changeInitiativeIdSelectorFactory, "changeInitiativeIdSelectorFactory cannot be null");
         checkNotNull(changeLogService, "changeLogService cannot be null");
 
         this.changeInitiativeDao = changeInitiativeDao;
         this.searchDao = searchDao;
         this.relationshipDao = relationshipDao;
-        this.changeInitiativeIdSelectorFactory = changeInitiativeIdSelectorFactory;
         this.changeLogService = changeLogService;
     }
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/change_set/ChangeSetService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/change_set/ChangeSetService.java
@@ -39,17 +39,14 @@ import static com.khartec.waltz.common.Checks.checkNotNull;
 public class ChangeSetService {
 
     private final ChangeSetDao changeSetDao;
-    private final ChangeSetIdSelectorFactory changeSetIdSelectorFactory;
+    private final ChangeSetIdSelectorFactory changeSetIdSelectorFactory = new ChangeSetIdSelectorFactory();
 
 
     @Autowired
-    public ChangeSetService(ChangeSetDao changeSetDao,
-                            ChangeSetIdSelectorFactory changeSetIdSelectorFactory) {
+    public ChangeSetService(ChangeSetDao changeSetDao) {
         checkNotNull(changeSetDao, "changeSetDao cannot be null");
-        checkNotNull(changeSetIdSelectorFactory, "changeSetIdSelectorFactory cannot be null");
 
         this.changeSetDao = changeSetDao;
-        this.changeSetIdSelectorFactory = changeSetIdSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/change_unit/ChangeUnitService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/change_unit/ChangeUnitService.java
@@ -46,23 +46,20 @@ public class ChangeUnitService {
 
     private final ChangeLogService changeLogService;
     private final ChangeUnitDao dao;
-    private final ChangeUnitIdSelectorFactory changeUnitIdSelectorFactory;
+    private final ChangeUnitIdSelectorFactory changeUnitIdSelectorFactory = new ChangeUnitIdSelectorFactory();
     private final Map<ChangeAction, ChangeUnitCommandProcessor> processorsByChangeAction;
 
 
     @Autowired
     public ChangeUnitService(ChangeLogService changeLogService,
-                             ChangeUnitDao dao,
-                             ChangeUnitIdSelectorFactory changeUnitIdSelectorFactory,
+                             ChangeUnitDao changeUnitDao,
                              List<ChangeUnitCommandProcessor> processors) {
         checkNotNull(changeLogService, "changeLogService cannot be null");
-        checkNotNull(changeUnitIdSelectorFactory, "changeUnitIdSelectorFactory cannot be null");
-        checkNotNull(dao, "dao cannot be null");
+        checkNotNull(changeUnitDao, "changeUnitDao cannot be null");
         checkNotNull(processors, "processors cannot be null");
 
         this.changeLogService = changeLogService;
-        this.changeUnitIdSelectorFactory = changeUnitIdSelectorFactory;
-        this.dao = dao;
+        this.dao = changeUnitDao;
 
         processorsByChangeAction = processors
                 .stream()

--- a/waltz-service/src/main/java/com/khartec/waltz/service/change_unit/processors/ModifyCommandProcessor.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/change_unit/processors/ModifyCommandProcessor.java
@@ -30,7 +30,6 @@ import com.khartec.waltz.model.physical_flow.PhysicalFlow;
 import com.khartec.waltz.service.attribute_change.AttributeChangeService;
 import com.khartec.waltz.service.change_unit.AttributeChangeCommandProcessor;
 import com.khartec.waltz.service.change_unit.ChangeUnitCommandProcessor;
-import com.khartec.waltz.service.changelog.ChangeLogService;
 import com.khartec.waltz.service.physical_flow.PhysicalFlowService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -47,27 +46,23 @@ import static java.util.stream.Collectors.toMap;
 public class ModifyCommandProcessor implements ChangeUnitCommandProcessor {
 
     private final AttributeChangeService attributeChangeService;
-    private final ChangeLogService changeLogService;
     private final PhysicalFlowService physicalFlowService;
     private final Map<String, AttributeChangeCommandProcessor> processorsByAttribute;
 
 
     @Autowired
     public ModifyCommandProcessor(AttributeChangeService attributeChangeService,
-                                  ChangeLogService changeLogService,
                                   PhysicalFlowService physicalFlowService,
                                   List<AttributeChangeCommandProcessor> processors) {
         checkNotNull(attributeChangeService, "attributeChangeService cannot be null");
-        checkNotNull(changeLogService, "changeLogService cannot be null");
         checkNotNull(physicalFlowService, "physicalFlowService cannot be null");
         checkNotNull(processors, "processors cannot be null");
 
         this.attributeChangeService = attributeChangeService;
-        this.changeLogService = changeLogService;
         this.physicalFlowService = physicalFlowService;
         this.processorsByAttribute = processors
                 .stream()
-                .collect(toMap(t -> t.supportedAttribute(), t -> t));
+                .collect(toMap(AttributeChangeCommandProcessor::supportedAttribute, t -> t));
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/change_unit/processors/RetireCommandProcessor.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/change_unit/processors/RetireCommandProcessor.java
@@ -30,7 +30,6 @@ import com.khartec.waltz.model.command.CommandResponse;
 import com.khartec.waltz.model.command.ImmutableCommandResponse;
 import com.khartec.waltz.model.physical_flow.PhysicalFlow;
 import com.khartec.waltz.service.change_unit.ChangeUnitCommandProcessor;
-import com.khartec.waltz.service.changelog.ChangeLogService;
 import com.khartec.waltz.service.physical_flow.PhysicalFlowService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -42,17 +41,13 @@ import static com.khartec.waltz.common.Checks.checkTrue;
 @Service
 public class RetireCommandProcessor implements ChangeUnitCommandProcessor {
 
-    private final ChangeLogService changeLogService;
     private final PhysicalFlowService physicalFlowService;
 
 
     @Autowired
-    public RetireCommandProcessor(ChangeLogService changeLogService,
-                                  PhysicalFlowService physicalFlowService) {
-        checkNotNull(changeLogService, "changeLogService cannot be null");
+    public RetireCommandProcessor(PhysicalFlowService physicalFlowService) {
         checkNotNull(physicalFlowService, "physicalFlowService cannot be null");
 
-        this.changeLogService = changeLogService;
         this.physicalFlowService = physicalFlowService;
     }
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/complexity/ComplexityRatingService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/complexity/ComplexityRatingService.java
@@ -54,27 +54,24 @@ public class ComplexityRatingService {
     private final ConnectionComplexityService connectionComplexityService;
     private final ServerComplexityService serverComplexityService;
 
-    private final ApplicationIdSelectorFactory appIdSelectorFactory;
+    private final ApplicationIdSelectorFactory appIdSelectorFactory = new ApplicationIdSelectorFactory();
 
 
     @Autowired
     public ComplexityRatingService(ComplexityScoreDao complexityScoreDao,
                                    MeasurableComplexityService measurableComplexityService,
                                    ConnectionComplexityService connectionComplexityService,
-                                   ServerComplexityService serverComplexityService,
-                                   ApplicationIdSelectorFactory appIdSelectorFactory) {
+                                   ServerComplexityService serverComplexityService) {
 
         checkNotNull(complexityScoreDao, "complexityScoreDao cannot be null");
         checkNotNull(measurableComplexityService, "measurableComplexityService cannot be null");
         checkNotNull(connectionComplexityService, "connectionComplexityService cannot be null");
         checkNotNull(serverComplexityService, "serverComplexityService cannot be null");
-        checkNotNull(appIdSelectorFactory, "appIdSelectorFactory cannot be null");
 
         this.complexityScoreDao = complexityScoreDao;
         this.measurableComplexityService = measurableComplexityService;
         this.connectionComplexityService = connectionComplexityService;
         this.serverComplexityService = serverComplexityService;
-        this.appIdSelectorFactory = appIdSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/data_flow_decorator/LogicalFlowDecoratorService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/data_flow_decorator/LogicalFlowDecoratorService.java
@@ -61,8 +61,8 @@ public class LogicalFlowDecoratorService {
 
     private final LogicalFlowDecoratorDao logicalFlowDecoratorDao;
     private final LogicalFlowDecoratorRatingsCalculator ratingsCalculator;
-    private final ApplicationIdSelectorFactory applicationIdSelectorFactory;
-    private final DataTypeIdSelectorFactory dataTypeIdSelectorFactory;
+    private final ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
+    private final DataTypeIdSelectorFactory dataTypeIdSelectorFactory = new DataTypeIdSelectorFactory();
     private final DataTypeUsageService dataTypeUsageService;
     private final LogicalFlowDao logicalFlowDao;
     private final ChangeLogService changeLogService;
@@ -71,24 +71,18 @@ public class LogicalFlowDecoratorService {
     @Autowired
     public LogicalFlowDecoratorService(LogicalFlowDecoratorDao logicalFlowDecoratorDao,
                                        LogicalFlowDecoratorRatingsCalculator ratingsCalculator,
-                                       ApplicationIdSelectorFactory applicationIdSelectorFactory,
-                                       DataTypeIdSelectorFactory dataTypeIdSelectorFactory,
                                        DataTypeUsageService dataTypeUsageService,
                                        LogicalFlowDao logicalFlowDao,
                                        ChangeLogService changeLogService) {
 
         checkNotNull(logicalFlowDecoratorDao, "logicalFlowDecoratorDao cannot be null");
-        checkNotNull(applicationIdSelectorFactory, "applicationIdSelectorFactory cannot be null");
         checkNotNull(ratingsCalculator, "ratingsCalculator cannot be null");
-        checkNotNull(dataTypeIdSelectorFactory, "dataTypeIdSelectorFactory cannot be null");
         checkNotNull(dataTypeUsageService, "dataTypeUsageService cannot be null");
         checkNotNull(logicalFlowDao, "logicalFlowDao cannot be null");
         checkNotNull(changeLogService, "changeLogService cannot be null");
 
         this.logicalFlowDecoratorDao = logicalFlowDecoratorDao;
         this.ratingsCalculator = ratingsCalculator;
-        this.applicationIdSelectorFactory = applicationIdSelectorFactory;
-        this.dataTypeIdSelectorFactory = dataTypeIdSelectorFactory;
         this.dataTypeUsageService = dataTypeUsageService;
         this.logicalFlowDao = logicalFlowDao;
         this.changeLogService = changeLogService;

--- a/waltz-service/src/main/java/com/khartec/waltz/service/database_information/DatabaseInformationService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/database_information/DatabaseInformationService.java
@@ -38,15 +38,12 @@ import static com.khartec.waltz.common.Checks.checkNotNull;
 public class DatabaseInformationService {
 
     private final DatabaseInformationDao databaseInformationDao;
-    private final ApplicationIdSelectorFactory factory;
+    private final ApplicationIdSelectorFactory factory = new ApplicationIdSelectorFactory();
 
     @Autowired
-    public DatabaseInformationService(DatabaseInformationDao databaseInformationDao, ApplicationIdSelectorFactory factory) {
+    public DatabaseInformationService(DatabaseInformationDao databaseInformationDao) {
         Checks.checkNotNull(databaseInformationDao, "databaseInformationDao cannot be null");
-        Checks.checkNotNull(factory, "factory cannot be null");
-
         this.databaseInformationDao = databaseInformationDao;
-        this.factory = factory;
     }
 
     public List<DatabaseInformation> findByApplicationId(Long id) {

--- a/waltz-service/src/main/java/com/khartec/waltz/service/end_user_app/EndUserAppService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/end_user_app/EndUserAppService.java
@@ -42,21 +42,14 @@ import static com.khartec.waltz.common.FunctionUtilities.time;
 public class EndUserAppService {
 
     private final EndUserAppDao endUserAppDao;
-    private final EndUserAppIdSelectorFactory endUserAppIdSelectorFactory;
-    private final OrganisationalUnitIdSelectorFactory orgUnitIdSelectorFactory;
+    private final EndUserAppIdSelectorFactory endUserAppIdSelectorFactory = new EndUserAppIdSelectorFactory();
+    private final OrganisationalUnitIdSelectorFactory orgUnitIdSelectorFactory= new OrganisationalUnitIdSelectorFactory();
 
 
     @Autowired
-    public EndUserAppService(EndUserAppDao endUserAppDao,
-                             EndUserAppIdSelectorFactory endUserAppIdSelectorFactory,
-                             OrganisationalUnitIdSelectorFactory orgUnitIdSelectorFactory) {
+    public EndUserAppService(EndUserAppDao endUserAppDao) {
         checkNotNull(endUserAppDao, "EndUserAppDao is required");
-        checkNotNull(endUserAppIdSelectorFactory, "endUserAppIdSelectorFactory cannot be null");
-        checkNotNull(orgUnitIdSelectorFactory, "orgUnitIdSelectorFactory cannot be null");
-
         this.endUserAppDao = endUserAppDao;
-        this.endUserAppIdSelectorFactory = endUserAppIdSelectorFactory;
-        this.orgUnitIdSelectorFactory = orgUnitIdSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/entity_hierarchy/EntityHierarchyService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/entity_hierarchy/EntityHierarchyService.java
@@ -58,7 +58,7 @@ public class EntityHierarchyService {
     private final ChangeInitiativeDao changeInitiativeDao;
     private final DataTypeDao dataTypeDao;
     private final EntityHierarchyDao entityHierarchyDao;
-    private final EntityRootsSelectorFactory entityRootsSelectorFactory;
+    private final EntityRootsSelectorFactory entityRootsSelectorFactory = new EntityRootsSelectorFactory();
     private final EntityStatisticDao entityStatisticDao;
     private final MeasurableDao measurableDao;
     private final OrganisationalUnitDao organisationalUnitDao;
@@ -69,7 +69,6 @@ public class EntityHierarchyService {
                                   ChangeInitiativeDao changeInitiativeDao,
                                   DataTypeDao dataTypeDao,
                                   EntityHierarchyDao entityHierarchyDao,
-                                  EntityRootsSelectorFactory entityRootsSelectorFactory,
                                   EntityStatisticDao entityStatisticDao,
                                   MeasurableDao measurableDao, 
                                   OrganisationalUnitDao organisationalUnitDao,
@@ -79,7 +78,6 @@ public class EntityHierarchyService {
         checkNotNull(changeInitiativeDao, "changeInitiativeDao cannot be null");
         checkNotNull(dataTypeDao, "dataTypeDao cannot be null");
         checkNotNull(entityHierarchyDao, "entityHierarchyDao cannot be null");
-        checkNotNull(entityRootsSelectorFactory, "entityRootsSelectorFactory cannot be null");
         checkNotNull(entityStatisticDao, "entityStatisticDao cannot be null");
         checkNotNull(measurableDao, "measurableDao cannot be null");
         checkNotNull(organisationalUnitDao, "organisationalUnitDao cannot be null");
@@ -89,7 +87,6 @@ public class EntityHierarchyService {
         this.changeInitiativeDao = changeInitiativeDao;
         this.dataTypeDao = dataTypeDao;
         this.entityHierarchyDao = entityHierarchyDao;
-        this.entityRootsSelectorFactory = entityRootsSelectorFactory;
         this.entityStatisticDao = entityStatisticDao;
         this.measurableDao = measurableDao;
         this.organisationalUnitDao = organisationalUnitDao;

--- a/waltz-service/src/main/java/com/khartec/waltz/service/entity_relationship/EntityRelationshipService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/entity_relationship/EntityRelationshipService.java
@@ -42,17 +42,13 @@ import static com.khartec.waltz.common.Checks.checkNotNull;
 public class EntityRelationshipService {
 
     private final EntityRelationshipDao entityRelationshipDao;
-    private final GenericSelectorFactory genericSelectorFactory;
+    private final GenericSelectorFactory genericSelectorFactory = new GenericSelectorFactory();
 
 
     @Autowired
-    public EntityRelationshipService(EntityRelationshipDao entityRelationshipDao,
-                                     GenericSelectorFactory genericSelectorFactory) {
+    public EntityRelationshipService(EntityRelationshipDao entityRelationshipDao) {
         checkNotNull(entityRelationshipDao, "entityRelationshipDao cannot be null");
-        checkNotNull(genericSelectorFactory, "genericSelectorFactory cannot be null");
-
         this.entityRelationshipDao = entityRelationshipDao;
-        this.genericSelectorFactory = genericSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/entity_statistic/EntityStatisticService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/entity_statistic/EntityStatisticService.java
@@ -53,7 +53,7 @@ import static java.util.Collections.emptyList;
 @Service
 public class EntityStatisticService {
 
-    private final ApplicationIdSelectorFactory factory;
+    private final ApplicationIdSelectorFactory factory = new ApplicationIdSelectorFactory();
     private final EntityStatisticValueDao valueDao;
     private final EntityStatisticDefinitionDao definitionDao;
     private final EntityStatisticSummaryDao summaryDao;
@@ -61,19 +61,16 @@ public class EntityStatisticService {
 
 
     @Autowired
-    public EntityStatisticService(ApplicationIdSelectorFactory factory,
-                                  EntityStatisticValueDao valueDao,
+    public EntityStatisticService(EntityStatisticValueDao valueDao,
                                   EntityStatisticDefinitionDao definitionDao,
                                   EntityStatisticSummaryDao summaryDao,
-                                  EntityStatisticDao statisticDao
-                                  ) {
-        checkNotNull(factory, "factory cannot be null");
+                                  EntityStatisticDao statisticDao)
+    {
         checkNotNull(valueDao, "valueDao cannot be null");
         checkNotNull(definitionDao, "definitionDao cannot be null");
         checkNotNull(summaryDao, "summaryDao cannot be null");
         checkNotNull(statisticDao, "statisticDao cannot be null");
 
-        this.factory = factory;
         this.valueDao = valueDao;
         this.definitionDao = definitionDao;
         this.summaryDao = summaryDao;
@@ -84,8 +81,7 @@ public class EntityStatisticService {
 
     public ImmediateHierarchy<EntityStatisticDefinition> getRelatedStatDefinitions(long id, boolean rollupOnly) {
         List<EntityStatisticDefinition> defs = definitionDao.findRelated(id, rollupOnly);
-        ImmediateHierarchy<EntityStatisticDefinition> relations = ImmediateHierarchyUtilities.build(id, defs);
-        return relations;
+        return ImmediateHierarchyUtilities.build(id, defs);
     }
 
 
@@ -116,7 +112,7 @@ public class EntityStatisticService {
         Select<Record1<Long>> appIdSelector = factory.apply(options);
 
         Map<RollupKind, Collection<Long>> definitionIdsByRollupKind = groupBy(
-                d -> d.rollupKind(),
+                EntityStatisticDefinition::rollupKind,
                 d -> d.id().orElse(null),
                 definitionDao.findByIds(statisticIds));
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/facet/FacetService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/facet/FacetService.java
@@ -40,16 +40,12 @@ public class FacetService {
 
     private final ApplicationDao applicationDao;
 
-    private final ApplicationIdSelectorFactory applicationIdSelectorFactory;
+    private final ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
 
 
     @Autowired
-    public FacetService(ApplicationDao applicationDao,
-                        ApplicationIdSelectorFactory applicationIdSelectorFactory) {
+    public FacetService(ApplicationDao applicationDao) {
         checkNotNull(applicationDao, "applicationDao cannot be null");
-        checkNotNull(applicationIdSelectorFactory, "applicationIdSelectorFactory cannot be null");
-
-        this.applicationIdSelectorFactory = applicationIdSelectorFactory;
         this.applicationDao = applicationDao;
     }
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/flow_diagram/FlowDiagramEntityService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/flow_diagram/FlowDiagramEntityService.java
@@ -43,21 +43,14 @@ import static com.khartec.waltz.common.ListUtilities.newArrayList;
 public class FlowDiagramEntityService {
 
     private final FlowDiagramEntityDao flowDiagramEntityDao;
-    private final FlowDiagramIdSelectorFactory flowDiagramIdSelectorFactory;
-    private final GenericSelectorFactory genericSelectorFactory;
+    private final FlowDiagramIdSelectorFactory flowDiagramIdSelectorFactory = new FlowDiagramIdSelectorFactory();
+    private final GenericSelectorFactory genericSelectorFactory = new GenericSelectorFactory();
 
 
     @Autowired
-    public FlowDiagramEntityService(FlowDiagramEntityDao flowDiagramEntityDao,
-                                    FlowDiagramIdSelectorFactory flowDiagramIdSelectorFactory,
-                                    GenericSelectorFactory genericSelectorFactory) {
+    public FlowDiagramEntityService(FlowDiagramEntityDao flowDiagramEntityDao) {
         checkNotNull(flowDiagramEntityDao, "flowDiagramEntityDao cannot be null");
-        checkNotNull(flowDiagramIdSelectorFactory, "flowDiagramIdSelectorFactory cannot be null");
-        checkNotNull(genericSelectorFactory, "genericSelectorFactory cannot be null");
-
         this.flowDiagramEntityDao = flowDiagramEntityDao;
-        this.flowDiagramIdSelectorFactory = flowDiagramIdSelectorFactory;
-        this.genericSelectorFactory = genericSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/flow_diagram/FlowDiagramService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/flow_diagram/FlowDiagramService.java
@@ -77,14 +77,14 @@ public class FlowDiagramService {
     private final FlowDiagramDao flowDiagramDao;
     private final FlowDiagramEntityDao flowDiagramEntityDao;
     private final FlowDiagramAnnotationDao flowDiagramAnnotationDao;
-    private final FlowDiagramIdSelectorFactory flowDiagramIdSelectorFactory;
     private final ApplicationDao applicationDao;
     private final LogicalFlowDao logicalFlowDao;
     private final PhysicalFlowDao physicalFlowDao;
     private final PhysicalSpecificationDao physicalSpecificationDao;
     private final ActorDao actorDao;
     private final Random rnd = RandomUtilities.getRandom();
-    private final LogicalFlowIdSelectorFactory logicalFlowIdSelectorFactory;
+    private final FlowDiagramIdSelectorFactory flowDiagramIdSelectorFactory = new FlowDiagramIdSelectorFactory();
+    private final LogicalFlowIdSelectorFactory logicalFlowIdSelectorFactory = new LogicalFlowIdSelectorFactory();
     private final MeasurableDao measurableDao;
     private final ChangeInitiativeDao changeInitiativeDao;
 
@@ -94,20 +94,17 @@ public class FlowDiagramService {
                               FlowDiagramDao flowDiagramDao,
                               FlowDiagramEntityDao flowDiagramEntityDao,
                               FlowDiagramAnnotationDao flowDiagramAnnotationDao,
-                              FlowDiagramIdSelectorFactory flowDiagramIdSelectorFactory,
                               ApplicationDao applicationDao,
                               LogicalFlowDao logicalFlowDao,
                               PhysicalFlowDao physicalFlowDao,
                               PhysicalSpecificationDao physicalSpecificationDao,
                               ActorDao actorDao,
                               MeasurableDao measurableDao,
-                              ChangeInitiativeDao changeInitiativeDao,
-                              LogicalFlowIdSelectorFactory logicalFlowIdSelectorFactory) {
+                              ChangeInitiativeDao changeInitiativeDao) {
         checkNotNull(changeLogService, "changeLogService cannot be null");
         checkNotNull(flowDiagramDao, "flowDiagramDao cannot be null");
         checkNotNull(flowDiagramEntityDao, "flowDiagramEntityDao cannot be null");
         checkNotNull(flowDiagramAnnotationDao, "flowDiagramAnnotationDao cannot be null");
-        checkNotNull(flowDiagramIdSelectorFactory, "flowDiagramIdSelectorFactory cannot be null");
         checkNotNull(applicationDao, "applicationDao cannot be null");
         checkNotNull(logicalFlowDao, "logicalFlowDao cannot be null");
         checkNotNull(physicalFlowDao, "physicalFlowDao cannot be null");
@@ -115,13 +112,11 @@ public class FlowDiagramService {
         checkNotNull(actorDao, "actorDao cannot be null");
         checkNotNull(measurableDao, "measurableDao cannot be null");
         checkNotNull(changeInitiativeDao, "changeInitiativeDao cannot be null");
-        checkNotNull(logicalFlowIdSelectorFactory, "logicalFlowIdSelectorFactory cannot be null");
 
         this.changeLogService = changeLogService;
         this.flowDiagramDao = flowDiagramDao;
         this.flowDiagramEntityDao = flowDiagramEntityDao;
         this.flowDiagramAnnotationDao = flowDiagramAnnotationDao;
-        this.flowDiagramIdSelectorFactory = flowDiagramIdSelectorFactory;
         this.applicationDao = applicationDao;
         this.logicalFlowDao = logicalFlowDao;
         this.physicalFlowDao = physicalFlowDao;
@@ -129,7 +124,6 @@ public class FlowDiagramService {
         this.actorDao = actorDao;
         this.measurableDao = measurableDao;
         this.changeInitiativeDao = changeInitiativeDao;
-        this.logicalFlowIdSelectorFactory = logicalFlowIdSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/involvement/InvolvementService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/involvement/InvolvementService.java
@@ -22,12 +22,12 @@ package com.khartec.waltz.service.involvement;
 import com.khartec.waltz.data.EntityReferenceNameResolver;
 import com.khartec.waltz.data.GenericSelector;
 import com.khartec.waltz.data.GenericSelectorFactory;
-import com.khartec.waltz.data.end_user_app.EndUserAppIdSelectorFactory;
 import com.khartec.waltz.data.involvement.InvolvementDao;
 import com.khartec.waltz.data.person.PersonDao;
 import com.khartec.waltz.model.EntityReference;
 import com.khartec.waltz.model.EntityReferenceUtilities;
 import com.khartec.waltz.model.IdSelectionOptions;
+import com.khartec.waltz.model.NameProvider;
 import com.khartec.waltz.model.application.Application;
 import com.khartec.waltz.model.changelog.ImmutableChangeLog;
 import com.khartec.waltz.model.involvement.EntityInvolvementChangeCommand;
@@ -56,11 +56,10 @@ public class InvolvementService {
 
     private final ChangeLogService changeLogService;
     private final InvolvementDao involvementDao;
-    private final EndUserAppIdSelectorFactory endUserAppIdSelectorFactory;
     private final EntityReferenceNameResolver entityReferenceNameResolver;
     private final InvolvementKindService involvementKindService;
     private final PersonDao personDao;
-    private final GenericSelectorFactory genericSelectorFactory;
+    private final GenericSelectorFactory genericSelectorFactory = new GenericSelectorFactory();
 
     private Map<Long, String> involvementKindIdToNameMap;
 
@@ -68,23 +67,17 @@ public class InvolvementService {
     @Autowired
     public InvolvementService(ChangeLogService changeLogService,
                               InvolvementDao dao,
-                              GenericSelectorFactory genericSelectorFactory,
-                              EndUserAppIdSelectorFactory endUserAppIdSelectorFactory,
                               EntityReferenceNameResolver entityReferenceNameResolver,
                               InvolvementKindService involvementKindService,
                               PersonDao personDao) {
         checkNotNull(changeLogService, "changeLogService cannot be null");
         checkNotNull(dao, "involvementDao must not be null");
-        checkNotNull(genericSelectorFactory, "genericSelectorFactory cannot be null");
-        checkNotNull(endUserAppIdSelectorFactory, "endUserAppIdSelectorFactory cannot be null");
         checkNotNull(entityReferenceNameResolver, "entityReferenceNameResolver cannot be null");
         checkNotNull(involvementKindService, "involvementKindService cannot be null");
         checkNotNull(personDao, "personDao cannot be null");
 
         this.changeLogService = changeLogService;
         this.involvementDao = dao;
-        this.genericSelectorFactory = genericSelectorFactory;
-        this.endUserAppIdSelectorFactory = endUserAppIdSelectorFactory;
         this.entityReferenceNameResolver = entityReferenceNameResolver;
         this.involvementKindService = involvementKindService;
         this.personDao = personDao;
@@ -211,7 +204,7 @@ public class InvolvementService {
         return applyToFirst(
                     entityReferenceNameResolver.resolve(newArrayList(ref)),
                     EntityReferenceUtilities::pretty)
-                .orElseGet(() -> ref.toString());
+                .orElseGet(ref::toString);
     }
 
 
@@ -219,7 +212,7 @@ public class InvolvementService {
         return involvementKindService
                 .findAll()
                 .stream()
-                .collect(Collectors.toMap(ik -> ik.id().get(), ik -> ik.name()));
+                .collect(Collectors.toMap(ik -> ik.id().get(), NameProvider::name));
     }
 
 }

--- a/waltz-service/src/main/java/com/khartec/waltz/service/licence/LicenceService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/licence/LicenceService.java
@@ -38,16 +38,13 @@ import static com.khartec.waltz.common.Checks.checkNotNull;
 public class LicenceService {
 
     private final LicenceDao licenceDao;
-    private final LicenceIdSelectorFactory licenceIdSelectorFactory;
+    private final LicenceIdSelectorFactory licenceIdSelectorFactory = new LicenceIdSelectorFactory();
 
 
     @Autowired
-    public LicenceService(LicenceDao licenceDao, LicenceIdSelectorFactory licenceIdSelectorFactory) {
+    public LicenceService(LicenceDao licenceDao) {
         checkNotNull(licenceDao, "licenceDao cannot be null");
-        checkNotNull(licenceIdSelectorFactory, "licenceIdSelectorFactory cannot be null");
-
         this.licenceDao = licenceDao;
-        this.licenceIdSelectorFactory = licenceIdSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/logical_data_element/LogicalDataElementService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/logical_data_element/LogicalDataElementService.java
@@ -10,7 +10,6 @@ import org.jooq.Record1;
 import org.jooq.Select;
 import org.springframework.stereotype.Service;
 
-import java.util.Collection;
 import java.util.List;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
@@ -20,19 +19,16 @@ public class LogicalDataElementService {
     
     private final LogicalDataElementDao logicalDataElementDao;
     private final LogicalDataElementSearchDao logicalDataElementSearchDao;
-    private final LogicalDataElementIdSelectorFactory idSelectorFactory;
+    private final LogicalDataElementIdSelectorFactory idSelectorFactory = new LogicalDataElementIdSelectorFactory();
 
 
     public LogicalDataElementService(LogicalDataElementDao logicalDataElementDao,
-                                     LogicalDataElementSearchDao logicalDataElementSearchDao,
-                                     LogicalDataElementIdSelectorFactory logicalDataElementIdSelectorFactory) {
+                                     LogicalDataElementSearchDao logicalDataElementSearchDao) {
         checkNotNull(logicalDataElementDao, "logicalDataElementDao cannot be null");
         checkNotNull(logicalDataElementSearchDao, "logicalDataElementSearchDao cannot be null");
-        checkNotNull(logicalDataElementIdSelectorFactory, "logicalDataElementIdSelectorFactory cannot be null");
 
         this.logicalDataElementDao = logicalDataElementDao;
         this.logicalDataElementSearchDao = logicalDataElementSearchDao;
-        this.idSelectorFactory = logicalDataElementIdSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/logical_flow/LogicalFlowService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/logical_flow/LogicalFlowService.java
@@ -69,45 +69,40 @@ import static org.jooq.lambda.tuple.Tuple.tuple;
 @Service
 public class LogicalFlowService {
 
-    private final ApplicationIdSelectorFactory appIdSelectorFactory;
     private final ChangeLogService changeLogService;
     private final DataTypeService dataTypeService;
     private final DataTypeUsageService dataTypeUsageService;
     private final DBExecutorPoolInterface dbExecutorPool;
     private final LogicalFlowDao logicalFlowDao;
-    private final LogicalFlowIdSelectorFactory logicalFlowIdSelectorFactory;
     private final LogicalFlowStatsDao logicalFlowStatsDao;
     private final LogicalFlowDecoratorDao logicalFlowDecoratorDao;
 
+    private final ApplicationIdSelectorFactory appIdSelectorFactory = new ApplicationIdSelectorFactory();
+    private final LogicalFlowIdSelectorFactory logicalFlowIdSelectorFactory = new LogicalFlowIdSelectorFactory();
+
 
     @Autowired
-    public LogicalFlowService(ApplicationIdSelectorFactory appIdSelectorFactory,
-                              ChangeLogService changeLogService,
+    public LogicalFlowService(ChangeLogService changeLogService,
                               DataTypeService dataTypeService,
                               DataTypeUsageService dataTypeUsageService,
                               DBExecutorPoolInterface dbExecutorPool,
                               LogicalFlowDecoratorDao logicalFlowDecoratorDao,
                               LogicalFlowDao logicalFlowDao,
-                              LogicalFlowIdSelectorFactory logicalFlowIdSelectorFactory,
                               LogicalFlowStatsDao logicalFlowStatsDao) {
-        checkNotNull(appIdSelectorFactory, "appIdSelectorFactory cannot be null");
         checkNotNull(changeLogService, "changeLogService cannot be null");
         checkNotNull(dbExecutorPool, "dbExecutorPool cannot be null");
         checkNotNull(dataTypeService, "dataTypeService cannot be null");
         checkNotNull(dataTypeUsageService, "dataTypeUsageService cannot be null");
         checkNotNull(logicalFlowDao, "logicalFlowDao must not be null");
         checkNotNull(logicalFlowDecoratorDao, "logicalFlowDecoratorDao cannot be null");
-        checkNotNull(logicalFlowIdSelectorFactory, "logicalFlowIdSelectorFactory cannot be null");
         checkNotNull(logicalFlowStatsDao, "logicalFlowStatsDao cannot be null");
 
-        this.appIdSelectorFactory = appIdSelectorFactory;
         this.changeLogService = changeLogService;
         this.dataTypeService = dataTypeService;
         this.dataTypeUsageService = dataTypeUsageService;
         this.dbExecutorPool = dbExecutorPool;
         this.logicalFlowDao = logicalFlowDao;
         this.logicalFlowDecoratorDao = logicalFlowDecoratorDao;
-        this.logicalFlowIdSelectorFactory = logicalFlowIdSelectorFactory;
         this.logicalFlowStatsDao = logicalFlowStatsDao;
     }
 
@@ -255,9 +250,9 @@ public class LogicalFlowService {
      *
      * todo: #WALTZ-1894 for cleanupOrphans task
      *
-     * @param flowId
-     * @param username
-     * @return
+     * @param flowId  identifier of flow to be removed
+     * @param username  who initiated the removal
+     * @return number of flows removed
      */
     public int removeFlow(Long flowId, String username) {
         LogicalFlow logicalFlow = logicalFlowDao.getByFlowId(flowId);

--- a/waltz-service/src/main/java/com/khartec/waltz/service/measurable/MeasurableService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/measurable/MeasurableService.java
@@ -49,7 +49,7 @@ import static java.util.Optional.ofNullable;
 public class MeasurableService {
     
     private final MeasurableDao measurableDao;
-    private final MeasurableIdSelectorFactory measurableIdSelectorFactory;
+    private final MeasurableIdSelectorFactory measurableIdSelectorFactory = new MeasurableIdSelectorFactory();
     private final MeasurableSearchDao measurableSearchDao;
     private final ChangeLogService changeLogService;
     private final EntityReferenceNameResolver nameResolver;
@@ -57,18 +57,15 @@ public class MeasurableService {
 
     @Autowired
     public MeasurableService(MeasurableDao measurableDao,
-                             MeasurableIdSelectorFactory measurableIdSelectorFactory,
                              MeasurableSearchDao measurableSearchDao,
                              EntityReferenceNameResolver nameResolver,
                              ChangeLogService changeLogService) {
         checkNotNull(measurableDao, "measurableDao cannot be null");
-        checkNotNull(measurableIdSelectorFactory, "measurableIdSelectorFactory cannot be null");
         checkNotNull(measurableSearchDao, "measurableSearchDao cannot be null");
         checkNotNull(nameResolver, "nameResolver cannot be null");
         checkNotNull(changeLogService, "changeLogService cannot be null");
 
         this.measurableDao = measurableDao;
-        this.measurableIdSelectorFactory = measurableIdSelectorFactory;
         this.measurableSearchDao = measurableSearchDao;
         this.nameResolver = nameResolver;
         this.changeLogService = changeLogService;
@@ -142,7 +139,7 @@ public class MeasurableService {
 
 
     public boolean updateExternalId(long id, String newValue, String userId) {
-        logUpdate(id, "externalId", newValue, m -> m.externalId(), userId);
+        logUpdate(id, "externalId", newValue, ExternalIdProvider::externalId, userId);
         return measurableDao.updateExternalId(id, newValue, userId);
     }
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/measurable_rating/MeasurableRatingService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/measurable_rating/MeasurableRatingService.java
@@ -56,35 +56,30 @@ public class MeasurableRatingService {
 
     private final MeasurableRatingDao measurableRatingDao;
     private final MeasurableDao measurableDao;
-    private final MeasurableIdSelectorFactory measurableIdSelectorFactory;
     private final PerspectiveRatingDao perspectiveRatingDao;
-    private final ApplicationIdSelectorFactory applicationIdSelectorFactory;
     private final ChangeLogService changeLogService;
     private final MeasurableCategoryDao measurableCategoryDao;
+
+    private final MeasurableIdSelectorFactory measurableIdSelectorFactory = new MeasurableIdSelectorFactory();
+    private final ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
 
 
     @Autowired
     public MeasurableRatingService(MeasurableRatingDao measurableRatingDao,
                                    MeasurableDao measurableDao,
                                    MeasurableCategoryDao measurableCategoryDao,
-                                   MeasurableIdSelectorFactory measurableIdSelectorFactory,
                                    PerspectiveRatingDao perspectiveRatingDao,
-                                   ApplicationIdSelectorFactory applicationIdSelectorFactory,
                                    ChangeLogService changeLogService) {
         checkNotNull(measurableRatingDao, "measurableRatingDao cannot be null");
         checkNotNull(measurableDao, "measurableDao cannot be null");
         checkNotNull(measurableCategoryDao, "measurableCategoryDao cannot be null");
-        checkNotNull(measurableIdSelectorFactory, "measurableIdSelectorFactory cannot be null");
         checkNotNull(perspectiveRatingDao, "perspectiveRatingDao cannot be null");
-        checkNotNull(applicationIdSelectorFactory, "applicationIdSelectorFactory cannot be null");
         checkNotNull(changeLogService, "changeLogService cannot be null");
 
         this.measurableRatingDao = measurableRatingDao;
         this.measurableDao = measurableDao;
         this.measurableCategoryDao = measurableCategoryDao;
-        this.measurableIdSelectorFactory = measurableIdSelectorFactory;
         this.perspectiveRatingDao = perspectiveRatingDao;
-        this.applicationIdSelectorFactory = applicationIdSelectorFactory;
         this.changeLogService = changeLogService;
     }
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/orgunit/OrganisationalUnitService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/orgunit/OrganisationalUnitService.java
@@ -20,7 +20,6 @@
 package com.khartec.waltz.service.orgunit;
 
 import com.khartec.waltz.data.orgunit.OrganisationalUnitDao;
-import com.khartec.waltz.data.orgunit.OrganisationalUnitIdSelectorFactory;
 import com.khartec.waltz.data.orgunit.search.OrganisationalUnitSearchDao;
 import com.khartec.waltz.model.EntityKind;
 import com.khartec.waltz.model.EntityReference;
@@ -43,20 +42,16 @@ public class OrganisationalUnitService {
 
     private final OrganisationalUnitDao dao;
     private final OrganisationalUnitSearchDao organisationalUnitSearchDao;
-    private final OrganisationalUnitIdSelectorFactory selectorFactory;
 
 
     @Autowired
     public OrganisationalUnitService(OrganisationalUnitDao dao,
-                                     OrganisationalUnitSearchDao organisationalUnitSearchDao,
-                                     OrganisationalUnitIdSelectorFactory orgUnitIdSelectorFactory) {
+                                     OrganisationalUnitSearchDao organisationalUnitSearchDao) {
         checkNotNull(dao, "dao must not be null");
         checkNotNull(organisationalUnitSearchDao, "organisationalUnitSearchDao must not be null");
-        checkNotNull(orgUnitIdSelectorFactory, "orgUnitIdSelectorFactory cannot be null");
 
         this.dao = dao;
         this.organisationalUnitSearchDao = organisationalUnitSearchDao;
-        this.selectorFactory = orgUnitIdSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/physical_flow/PhysicalFlowService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/physical_flow/PhysicalFlowService.java
@@ -61,7 +61,7 @@ public class PhysicalFlowService {
     private final ChangeLogService changeLogService;
     private final LogicalFlowService logicalFlowService;
     private final PhysicalFlowSearchDao searchDao;
-    private final PhysicalFlowIdSelectorFactory physicalFlowIdSelectorFactory;
+    private final PhysicalFlowIdSelectorFactory physicalFlowIdSelectorFactory = new PhysicalFlowIdSelectorFactory();
 
 
     @Autowired
@@ -69,16 +69,12 @@ public class PhysicalFlowService {
                                LogicalFlowService logicalFlowService,
                                PhysicalFlowDao physicalDataFlowDao,
                                PhysicalSpecificationDao physicalSpecificationDao,
-                               PhysicalFlowSearchDao searchDao,
-                               PhysicalFlowIdSelectorFactory physicalFlowIdSelectorFactory) {
-        this.physicalFlowIdSelectorFactory = physicalFlowIdSelectorFactory;
-
+                               PhysicalFlowSearchDao searchDao) {
         checkNotNull(changeLogService, "changeLogService cannot be null");
         checkNotNull(logicalFlowService, "logicalFlowService cannot be null");
         checkNotNull(physicalDataFlowDao, "physicalFlowDao cannot be null");
         checkNotNull(physicalSpecificationDao, "physicalSpecificationDao cannot be null");
         checkNotNull(searchDao, "searchDao cannot be null");
-        checkNotNull(physicalFlowIdSelectorFactory, "physicalFlowIdSelectorFactory cannot be null");
 
         this.changeLogService = changeLogService;
         this.logicalFlowService = logicalFlowService;

--- a/waltz-service/src/main/java/com/khartec/waltz/service/physical_specification/PhysicalSpecificationService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/physical_specification/PhysicalSpecificationService.java
@@ -53,24 +53,21 @@ public class PhysicalSpecificationService {
     private final ChangeLogService changeLogService;
     private final PhysicalSpecificationDao specificationDao;
     private final PhysicalSpecificationSearchDao specificationSearchDao;
-    private final PhysicalSpecificationIdSelectorFactory idSelectorFactory;
+    private final PhysicalSpecificationIdSelectorFactory idSelectorFactory = new PhysicalSpecificationIdSelectorFactory();
 
 
     @Autowired
     public PhysicalSpecificationService(ChangeLogService changeLogService,
                                         PhysicalSpecificationDao specificationDao,
-                                        PhysicalSpecificationSearchDao specificationSearchDao,
-                                        PhysicalSpecificationIdSelectorFactory idSelectorFactory)
+                                        PhysicalSpecificationSearchDao specificationSearchDao)
     {
         checkNotNull(changeLogService, "changeLogService cannot be null");
         checkNotNull(specificationDao, "specificationDao cannot be null");
         checkNotNull(specificationSearchDao, "specificationSearchDao cannot be null");
-        checkNotNull(idSelectorFactory, "idSelectorFactory cannot be null");
 
         this.changeLogService = changeLogService;
         this.specificationDao = specificationDao;
         this.specificationSearchDao = specificationSearchDao;
-        this.idSelectorFactory = idSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/physical_specification_data_type/PhysicalSpecDataTypeService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/physical_specification_data_type/PhysicalSpecDataTypeService.java
@@ -23,6 +23,7 @@ import com.khartec.waltz.data.physical_specification.PhysicalSpecificationIdSele
 import com.khartec.waltz.data.physical_specification_data_type.PhysicalSpecDataTypeDao;
 import com.khartec.waltz.model.*;
 import com.khartec.waltz.model.changelog.ImmutableChangeLog;
+import com.khartec.waltz.model.physical_flow.PhysicalFlow;
 import com.khartec.waltz.model.physical_specification_data_type.ImmutablePhysicalSpecificationDataType;
 import com.khartec.waltz.model.physical_specification_data_type.PhysicalSpecificationDataType;
 import com.khartec.waltz.service.changelog.ChangeLogService;
@@ -51,26 +52,23 @@ public class PhysicalSpecDataTypeService {
     private final LogicalFlowDecoratorService logicalFlowDecoratorService;
     private final PhysicalFlowService physicalFlowService;
     private final PhysicalSpecDataTypeDao physicalSpecDataTypeDao;
-    private final PhysicalSpecificationIdSelectorFactory specificationIdSelectorFactory;
+    private final PhysicalSpecificationIdSelectorFactory specificationIdSelectorFactory = new PhysicalSpecificationIdSelectorFactory();
 
 
     @Autowired
     public PhysicalSpecDataTypeService(ChangeLogService changeLogService,
                                        LogicalFlowDecoratorService logicalFlowDecoratorService,
                                        PhysicalFlowService physicalFlowService,
-                                       PhysicalSpecDataTypeDao physicalSpecDataTypeDao,
-                                       PhysicalSpecificationIdSelectorFactory specificationIdSelectorFactory) {
+                                       PhysicalSpecDataTypeDao physicalSpecDataTypeDao) {
         checkNotNull(changeLogService, "changeLogService cannot be null");
         checkNotNull(logicalFlowDecoratorService, "logicalFlowDecoratorService cannot be null");
         checkNotNull(physicalFlowService, "physicalFlowService cannot be null");
         checkNotNull(physicalSpecDataTypeDao, "physicalSpecDataTypeDao cannot be null");
-        checkNotNull(specificationIdSelectorFactory, "specificationIdSelectorFactory cannot be null");
 
         this.changeLogService = changeLogService;
         this.logicalFlowDecoratorService = logicalFlowDecoratorService;
         this.physicalFlowService = physicalFlowService;
         this.physicalSpecDataTypeDao = physicalSpecDataTypeDao;
-        this.specificationIdSelectorFactory = specificationIdSelectorFactory;
     }
 
 
@@ -108,7 +106,7 @@ public class PhysicalSpecDataTypeService {
         List<Long> logicalFlowIds = physicalFlowService
                 .findBySpecificationId(specificationId)
                 .stream()
-                .map(f -> f.logicalFlowId())
+                .map(PhysicalFlow::logicalFlowId)
                 .collect(toList());
 
         Set<EntityReference> dataTypeRefs = dataTypeIds.stream()

--- a/waltz-service/src/main/java/com/khartec/waltz/service/physical_specification_definition/PhysicalSpecDefinitionFieldService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/physical_specification_definition/PhysicalSpecDefinitionFieldService.java
@@ -43,20 +43,17 @@ public class PhysicalSpecDefinitionFieldService {
 
     private final ChangeLogService changeLogService;
     private final PhysicalSpecDefinitionFieldDao dao;
-    private final PhysicalSpecDefnFieldIdSelectorFactory idSelectorFactory;
+    private final PhysicalSpecDefnFieldIdSelectorFactory idSelectorFactory = new PhysicalSpecDefnFieldIdSelectorFactory();
 
 
     @Autowired
     public PhysicalSpecDefinitionFieldService(ChangeLogService changeLogService,
-                                              PhysicalSpecDefinitionFieldDao dao,
-                                              PhysicalSpecDefnFieldIdSelectorFactory physicalSpecDefnFieldIdSelectorFactory) {
+                                              PhysicalSpecDefinitionFieldDao dao) {
         checkNotNull(changeLogService, "changeLogService cannot be null");
         checkNotNull(dao, "dao cannot be null");
-        checkNotNull(physicalSpecDefnFieldIdSelectorFactory, "idSelectorFactory cannot be null");
 
         this.changeLogService = changeLogService;
         this.dao = dao;
-        this.idSelectorFactory = physicalSpecDefnFieldIdSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/physical_specification_definition/PhysicalSpecDefinitionService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/physical_specification_definition/PhysicalSpecDefinitionService.java
@@ -52,25 +52,22 @@ public class PhysicalSpecDefinitionService {
     private final PhysicalSpecDefinitionFieldDao physicalSpecDefinitionFieldDao;
     private final PhysicalSpecDefinitionSampleFileDao physicalSpecDefinitionSampleFileDao;
     private final Map<ReleaseLifecycleStatus, List<ReleaseLifecycleStatus>> stateTransitions;
-    private final PhysicalSpecDefnIdSelectorFactory physicalSpecDefnIdSelectorFactory;
+    private final PhysicalSpecDefnIdSelectorFactory physicalSpecDefnIdSelectorFactory = new PhysicalSpecDefnIdSelectorFactory();
 
 
     @Autowired
     public PhysicalSpecDefinitionService(ChangeLogService changeLogService,
                                          PhysicalSpecDefinitionDao physicalSpecDefinitionDao,
                                          PhysicalSpecDefinitionFieldDao physicalSpecDefinitionFieldDao,
-                                         PhysicalSpecDefnIdSelectorFactory physicalSpecDefnIdSelectorFactory,
                                          PhysicalSpecDefinitionSampleFileDao physicalSpecDefinitionSampleFileDao) {
         checkNotNull(changeLogService, "changeLogService cannot be null");
         checkNotNull(physicalSpecDefinitionDao, "physicalSpecDefinitionDao cannot be null");
         checkNotNull(physicalSpecDefinitionFieldDao, "physicalSpecDefinitionFieldDao cannot be null");
-        checkNotNull(physicalSpecDefnIdSelectorFactory, "physicalSpecDefnIdSelectorFactory cannot be null");
         checkNotNull(physicalSpecDefinitionSampleFileDao, "physicalSpecDefinitionSampleFileDao cannot be null");
 
         this.changeLogService = changeLogService;
         this.physicalSpecDefinitionDao = physicalSpecDefinitionDao;
         this.physicalSpecDefinitionFieldDao = physicalSpecDefinitionFieldDao;
-        this.physicalSpecDefnIdSelectorFactory = physicalSpecDefnIdSelectorFactory;
         this.physicalSpecDefinitionSampleFileDao = physicalSpecDefinitionSampleFileDao;
 
         // initialise valid state transitions

--- a/waltz-service/src/main/java/com/khartec/waltz/service/roadmap/RoadmapService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/roadmap/RoadmapService.java
@@ -35,7 +35,7 @@ public class RoadmapService {
     private final RoadmapDao roadmapDao;
     private final RoadmapSearchDao roadmapSearchDao;
     private final ScenarioDao scenarioDao;
-    private final RoadmapIdSelectorFactory roadmapIdSelectorFactory;
+    private final RoadmapIdSelectorFactory roadmapIdSelectorFactory = new RoadmapIdSelectorFactory();
     private final ChangeLogService changeLogService;
     private final EntityRelationshipDao entityRelationshipDao;
 
@@ -44,19 +44,16 @@ public class RoadmapService {
     public RoadmapService(RoadmapDao roadmapDao,
                           RoadmapSearchDao roadmapSearchDao,
                           ScenarioDao scenarioDao,
-                          RoadmapIdSelectorFactory roadmapIdSelectorFactory,
                           ChangeLogService changeLogService,
                           EntityRelationshipDao entityRelationshipDao) {
         checkNotNull(roadmapDao, "roadmapDao cannot be null");
         checkNotNull(roadmapSearchDao, "roadmapSearchDao cannot be null");
         checkNotNull(scenarioDao, "scenarioDao cannot be null");
-        checkNotNull(roadmapIdSelectorFactory, "roadmapIdSelectorFactory cannot be null");
         checkNotNull(changeLogService, "changeLogService cannot be null");
         checkNotNull(entityRelationshipDao, "entityRelationshipDao cannot be null");
         this.roadmapDao = roadmapDao;
         this.roadmapSearchDao = roadmapSearchDao;
         this.scenarioDao = scenarioDao;
-        this.roadmapIdSelectorFactory = roadmapIdSelectorFactory;
         this.changeLogService = changeLogService;
         this.entityRelationshipDao = entityRelationshipDao;
     }
@@ -154,7 +151,7 @@ public class RoadmapService {
     public List<EntityReference> search(String query) {
         List<Roadmap> roadmaps = search(query, EntitySearchOptions.mkForEntity(EntityKind.ROADMAP));
         return roadmaps.stream()
-                .map(a -> a.entityReference())
+                .map(Roadmap::entityReference)
                 .collect(toList());
     }
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/scenario/ScenarioService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/scenario/ScenarioService.java
@@ -29,7 +29,7 @@ public class ScenarioService {
     private final ScenarioDao scenarioDao;
     private final ScenarioAxisItemDao scenarioAxisItemDao;
     private final ScenarioRatingItemDao scenarioRatingItemDao;
-    private final RoadmapIdSelectorFactory roadmapIdSelectorFactory;
+    private final RoadmapIdSelectorFactory roadmapIdSelectorFactory = new RoadmapIdSelectorFactory();
     private final ChangeLogService changeLogService;
 
 
@@ -37,16 +37,14 @@ public class ScenarioService {
     public ScenarioService(ScenarioDao scenarioDao,
                            ScenarioAxisItemDao scenarioAxisItemDao,
                            ScenarioRatingItemDao scenarioRatingItemDao,
-                           RoadmapIdSelectorFactory roadmapIdSelectorFactory, ChangeLogService changeLogService) {
+                           ChangeLogService changeLogService) {
         checkNotNull(scenarioDao, "scenarioDao cannot be null");
         checkNotNull(scenarioAxisItemDao, "scenarioAxisItemDao cannot be null");
         checkNotNull(scenarioRatingItemDao, "scenarioRatingItemDao cannot be null");
-        checkNotNull(roadmapIdSelectorFactory, "roadmapIdSelectorFactory cannot be null");
         checkNotNull(changeLogService, "changeLogService cannot be null");
         this.scenarioDao = scenarioDao;
         this.scenarioAxisItemDao = scenarioAxisItemDao;
         this.scenarioRatingItemDao = scenarioRatingItemDao;
-        this.roadmapIdSelectorFactory = roadmapIdSelectorFactory;
         this.changeLogService = changeLogService;
     }
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/server_information/ServerInformationService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/server_information/ServerInformationService.java
@@ -40,20 +40,17 @@ import static com.khartec.waltz.common.Checks.checkNotNull;
 @Service
 public class ServerInformationService {
 
-    private final ApplicationIdSelectorFactory selectorFactory;
+    private final ApplicationIdSelectorFactory selectorFactory = new ApplicationIdSelectorFactory();
     private final ServerInformationDao serverInformationDao;
     private final ServerInformationSearchDao serverInformationSearchDao;
 
 
     @Autowired
-    public ServerInformationService(ApplicationIdSelectorFactory selectorFactory,
-                                    ServerInformationDao serverInfoDao,
+    public ServerInformationService(ServerInformationDao serverInfoDao,
                                     ServerInformationSearchDao serverInformationSearchDao) {
-        checkNotNull(selectorFactory, "selectorFactory cannot be null");
         checkNotNull(serverInfoDao, "serverInformationDao must not be null");
         checkNotNull(serverInformationSearchDao, "serverInformationSearchDao cannot be null");
 
-        this.selectorFactory = selectorFactory;
         this.serverInformationDao = serverInfoDao;
         this.serverInformationSearchDao = serverInformationSearchDao;
     }

--- a/waltz-service/src/main/java/com/khartec/waltz/service/survey/SurveyInstanceIdSelectorFactory.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/survey/SurveyInstanceIdSelectorFactory.java
@@ -25,31 +25,19 @@ import com.khartec.waltz.model.EntityReference;
 import com.khartec.waltz.model.HierarchyQueryScope;
 import com.khartec.waltz.model.IdSelectionOptions;
 import com.khartec.waltz.model.ImmutableIdSelectionOptions;
-import org.jooq.DSLContext;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.jooq.SelectConditionStep;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import org.jooq.impl.DSL;
 
 import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.common.Checks.checkTrue;
 import static com.khartec.waltz.model.HierarchyQueryScope.EXACT;
 import static com.khartec.waltz.schema.tables.SurveyInstance.SURVEY_INSTANCE;
 
-@Service
 public class SurveyInstanceIdSelectorFactory implements IdSelectorFactory {
-    private final DSLContext dsl;
 
-    private final OrganisationalUnitIdSelectorFactory orgUnitIdSelectorFactory;
-
-
-    @Autowired
-    public SurveyInstanceIdSelectorFactory(DSLContext dsl,
-                                           OrganisationalUnitIdSelectorFactory orgUnitIdSelectorFactory) {
-        this.dsl = dsl;
-        this.orgUnitIdSelectorFactory = orgUnitIdSelectorFactory;
-    }
+    private final OrganisationalUnitIdSelectorFactory orgUnitIdSelectorFactory = new OrganisationalUnitIdSelectorFactory();
 
 
     @Override
@@ -76,7 +64,7 @@ public class SurveyInstanceIdSelectorFactory implements IdSelectorFactory {
     private Select<Record1<Long>> mkForNonHierarchicalEntity(EntityReference ref, HierarchyQueryScope scope) {
         checkTrue(scope == EXACT, "Can only create selector for exact matches if given a non-hierarchical ref");
 
-        return dsl
+        return DSL
                 .select(SURVEY_INSTANCE.ID)
                 .from(SURVEY_INSTANCE)
                 .where(SURVEY_INSTANCE.ENTITY_KIND.eq(ref.kind().name())
@@ -94,7 +82,7 @@ public class SurveyInstanceIdSelectorFactory implements IdSelectorFactory {
 
         Select<Record1<Long>> ouSelector = orgUnitIdSelectorFactory.apply(ouSelectorOptions);
 
-        return dsl
+        return DSL
                 .selectDistinct(SURVEY_INSTANCE.ID)
                 .from(SURVEY_INSTANCE)
                 .where(SURVEY_INSTANCE.ENTITY_KIND.eq(ref.kind().name())

--- a/waltz-service/src/main/java/com/khartec/waltz/service/survey/SurveyInstanceService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/survey/SurveyInstanceService.java
@@ -55,7 +55,7 @@ public class SurveyInstanceService {
     private final SurveyInstanceRecipientDao surveyInstanceRecipientDao;
     private final SurveyQuestionResponseDao surveyQuestionResponseDao;
 
-    private final SurveyInstanceIdSelectorFactory surveyInstanceIdSelectorFactory;
+    private final SurveyInstanceIdSelectorFactory surveyInstanceIdSelectorFactory = new SurveyInstanceIdSelectorFactory();
     private SurveyRunDao surveyRunDao;
     private UserRoleService userRoleService;
 
@@ -67,15 +67,13 @@ public class SurveyInstanceService {
                                  SurveyInstanceRecipientDao surveyInstanceRecipientDao,
                                  SurveyQuestionResponseDao surveyQuestionResponseDao,
                                  SurveyRunDao surveyRunDao,
-                                 UserRoleService userRoleService,
-                                 SurveyInstanceIdSelectorFactory surveyInstanceIdSelectorFactory) {
+                                 UserRoleService userRoleService) {
         checkNotNull(changeLogService, "changeLogService cannot be null");
         checkNotNull(personDao, "personDao cannot be null");
         checkNotNull(surveyInstanceDao, "surveyInstanceDao cannot be null");
         checkNotNull(surveyInstanceRecipientDao, "surveyInstanceRecipientDao cannot be null");
         checkNotNull(surveyQuestionResponseDao, "surveyQuestionResponseDao cannot be null");
         checkNotNull(surveyRunDao, "surveyRunDao cannot be null");
-        checkNotNull(surveyInstanceIdSelectorFactory, "surveyInstanceIdSelectorFactory cannot be null");
         checkNotNull(userRoleService, "userRoleService cannot be null");
 
         this.changeLogService = changeLogService;
@@ -85,7 +83,6 @@ public class SurveyInstanceService {
         this.surveyQuestionResponseDao = surveyQuestionResponseDao;
         this.surveyRunDao = surveyRunDao;
         this.userRoleService = userRoleService;
-        this.surveyInstanceIdSelectorFactory = surveyInstanceIdSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/survey/SurveyRunService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/survey/SurveyRunService.java
@@ -54,7 +54,6 @@ import static java.util.stream.Collectors.toList;
 public class SurveyRunService {
 
     private final ChangeLogService changeLogService;
-    private final GenericSelectorFactory genericSelectorFactory;
     private final InvolvementDao involvementDao;
     private final PersonDao personDao;
     private final SurveyInstanceDao surveyInstanceDao;
@@ -62,38 +61,33 @@ public class SurveyRunService {
     private final SurveyRunDao surveyRunDao;
     private final SurveyTemplateDao surveyTemplateDao;
 
-    private final SurveyInstanceIdSelectorFactory surveyInstanceIdSelectorFactory;
+    private final GenericSelectorFactory genericSelectorFactory = new GenericSelectorFactory();
+    private final SurveyInstanceIdSelectorFactory surveyInstanceIdSelectorFactory = new SurveyInstanceIdSelectorFactory();
 
 
     @Autowired
     public SurveyRunService(ChangeLogService changeLogService,
-                            GenericSelectorFactory genericSelectorFactory,
                             InvolvementDao involvementDao,
                             PersonDao personDao,
                             SurveyInstanceDao surveyInstanceDao,
                             SurveyInstanceRecipientDao surveyInstanceRecipientDao,
                             SurveyRunDao surveyRunDao,
-                            SurveyTemplateDao surveyTemplateDao,
-                            SurveyInstanceIdSelectorFactory surveyInstanceIdSelectorFactory) {
+                            SurveyTemplateDao surveyTemplateDao) {
         checkNotNull(changeLogService, "changeLogService cannot be null");
-        checkNotNull(genericSelectorFactory, "genericSelectorFactory cannot be null");
         checkNotNull(involvementDao, "involvementDao cannot be null");
         checkNotNull(personDao, "personDao cannot be null");
         checkNotNull(surveyInstanceDao, "surveyInstanceDao cannot be null");
         checkNotNull(surveyInstanceRecipientDao, "surveyInstanceRecipientDao cannot be null");
         checkNotNull(surveyRunDao, "surveyRunDao cannot be null");
         checkNotNull(surveyTemplateDao, "surveyTemplateDao cannot be null");
-        checkNotNull(surveyInstanceIdSelectorFactory, "surveyInstanceIdSelectorFactory cannot be null");
 
         this.changeLogService = changeLogService;
-        this.genericSelectorFactory = genericSelectorFactory;
         this.involvementDao = involvementDao;
         this.personDao = personDao;
         this.surveyInstanceDao = surveyInstanceDao;
         this.surveyInstanceRecipientDao = surveyInstanceRecipientDao;
         this.surveyRunDao = surveyRunDao;
         this.surveyTemplateDao = surveyTemplateDao;
-        this.surveyInstanceIdSelectorFactory = surveyInstanceIdSelectorFactory;
     }
 
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/usage_info/DataTypeUsageService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/usage_info/DataTypeUsageService.java
@@ -54,21 +54,14 @@ import static com.khartec.waltz.schema.tables.Application.APPLICATION;
 public class DataTypeUsageService {
 
     private final DataTypeUsageDao dataTypeUsageDao;
-    private final ApplicationIdSelectorFactory appIdSelectorFactor;
-    private final DataTypeIdSelectorFactory dataTypeIdSelectorFactory;
+    private final ApplicationIdSelectorFactory appIdSelectorFactor = new ApplicationIdSelectorFactory();
+    private final DataTypeIdSelectorFactory dataTypeIdSelectorFactory = new DataTypeIdSelectorFactory();
 
 
     @Autowired
-    public DataTypeUsageService(DataTypeUsageDao dataTypeUsageDao,
-                                ApplicationIdSelectorFactory selectorFactory,
-                                DataTypeIdSelectorFactory dataTypeIdSelectorFactory) {
+    public DataTypeUsageService(DataTypeUsageDao dataTypeUsageDao) {
         checkNotNull(dataTypeUsageDao, "dataTypeUsageDao cannot be null");
-        checkNotNull(selectorFactory, "appIdSelectorFactor cannot be null");
-        checkNotNull(dataTypeIdSelectorFactory, "dataTypeIdSelectorFactory cannot be null");
-
         this.dataTypeUsageDao = dataTypeUsageDao;
-        this.appIdSelectorFactor = selectorFactory;
-        this.dataTypeIdSelectorFactory = dataTypeIdSelectorFactory;
     }
 
 

--- a/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/AllocationsExtractor.java
+++ b/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/AllocationsExtractor.java
@@ -37,13 +37,12 @@ import static spark.Spark.post;
 @Service
 public class AllocationsExtractor extends BaseDataExtractor{
 
-    private final ApplicationIdSelectorFactory applicationIdSelectorFactory;
+    private final ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
 
 
     @Autowired
-    public AllocationsExtractor(DSLContext dsl, ApplicationIdSelectorFactory applicationIdSelectorFactory) {
+    public AllocationsExtractor(DSLContext dsl) {
         super(dsl);
-        this.applicationIdSelectorFactory = applicationIdSelectorFactory;
     }
 
 
@@ -104,7 +103,8 @@ public class AllocationsExtractor extends BaseDataExtractor{
 
             ApplicationIdSelectionOptions applicationIdSelectionOptions = readAppIdSelectionOptionsFromBody(request);
 
-            Record2<String, String> fileNameInfoRow = dsl.select(MEASURABLE_CATEGORY.NAME, ALLOCATION_SCHEME.NAME)
+            Record2<String, String> fileNameInfoRow = dsl
+                    .select(MEASURABLE_CATEGORY.NAME, ALLOCATION_SCHEME.NAME)
                     .from(ALLOCATION_SCHEME)
                     .innerJoin(MEASURABLE_CATEGORY).on(ALLOCATION_SCHEME.MEASURABLE_CATEGORY_ID.eq(MEASURABLE_CATEGORY.ID))
                     .where(ALLOCATION_SCHEME.ID.eq(schemeId))

--- a/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/ComplexityExtractor.java
+++ b/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/ComplexityExtractor.java
@@ -24,8 +24,6 @@ import com.khartec.waltz.data.application.ApplicationIdSelectorFactory;
 import com.khartec.waltz.model.EntityKind;
 import com.khartec.waltz.model.application.ApplicationIdSelectionOptions;
 import org.jooq.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -42,15 +40,13 @@ import static spark.Spark.post;
 @Service
 public class ComplexityExtractor extends BaseDataExtractor {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ComplexityExtractor.class);
-    private final ApplicationIdSelectorFactory applicationIdSelectorFactory;
+    private final ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
 
 
     @Autowired
-    public ComplexityExtractor(DSLContext dsl, ApplicationIdSelectorFactory applicationIdSelectorFactory) {
+    public ComplexityExtractor(DSLContext dsl) {
         super(dsl);
         checkNotNull(applicationIdSelectorFactory, "applicationIdSelectorFactory cannot be null");
-        this.applicationIdSelectorFactory = applicationIdSelectorFactory;
     }
 
 

--- a/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/MeasurableRatingExtractor.java
+++ b/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/MeasurableRatingExtractor.java
@@ -27,6 +27,7 @@ import com.khartec.waltz.model.application.ApplicationIdSelectionOptions;
 import com.khartec.waltz.schema.Tables;
 import com.khartec.waltz.schema.tables.*;
 import org.jooq.*;
+import org.jooq.impl.DSL;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -41,7 +42,7 @@ import static spark.Spark.post;
 @Service
 public class MeasurableRatingExtractor extends BaseDataExtractor {
 
-    private final ApplicationIdSelectorFactory applicationIdSelectorFactory;
+    private final ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
     private final Measurable m = MEASURABLE.as("m");
     private final Application app = APPLICATION.as("app");
     private final MeasurableCategory mc = Tables.MEASURABLE_CATEGORY.as("mc");
@@ -51,10 +52,8 @@ public class MeasurableRatingExtractor extends BaseDataExtractor {
 
 
     @Autowired
-    public MeasurableRatingExtractor(DSLContext dsl,
-                                     ApplicationIdSelectorFactory applicationIdSelectorFactory) {
+    public MeasurableRatingExtractor(DSLContext dsl) {
         super(dsl);
-        this.applicationIdSelectorFactory = applicationIdSelectorFactory;
     }
 
 
@@ -75,7 +74,7 @@ public class MeasurableRatingExtractor extends BaseDataExtractor {
             Select<Record1<Long>> appSelector = applicationIdSelectorFactory.apply(selectionOpts);
 
 
-            SelectSelectStep<Record> reportColumns = dsl
+            SelectSelectStep<Record> reportColumns = DSL
                     .select(m.NAME.as("Taxonomy Item Name"),
                             m.EXTERNAL_ID.as("Taxonomy Item Code"))
                     .select(app.NAME.as("App Name"),
@@ -122,7 +121,7 @@ public class MeasurableRatingExtractor extends BaseDataExtractor {
             ApplicationIdSelectionOptions selectionOpts = readAppIdSelectionOptionsFromBody(request);
             Select<Record1<Long>> appIds = applicationIdSelectorFactory.apply(selectionOpts);
 
-            SelectConditionStep<Record1<Long>> appIdsAssignedToAnyMeasurableInTheCategory = dsl
+            SelectConditionStep<Record1<Long>> appIdsAssignedToAnyMeasurableInTheCategory = DSL
                     .selectDistinct(MEASURABLE_RATING.ENTITY_ID)
                     .from(MEASURABLE_RATING)
                     .join(MEASURABLE)
@@ -130,7 +129,7 @@ public class MeasurableRatingExtractor extends BaseDataExtractor {
                     .where(MEASURABLE_RATING.ENTITY_KIND.eq(EntityKind.APPLICATION.name())
                             .and(MEASURABLE.MEASURABLE_CATEGORY_ID.eq(categoryId)));
 
-            SelectSeekStep1<Record4<String, String, Long, String>, String> qry = dsl
+            SelectSeekStep1<Record4<String, String, Long, String>, String> qry = DSL
                     .selectDistinct(app.NAME.as("App Name"),
                             app.ASSET_CODE.as("App Code"),
                             app.ID.as("App Waltz Id"),

--- a/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/PeopleExtractor.java
+++ b/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/PeopleExtractor.java
@@ -42,13 +42,12 @@ import static spark.Spark.post;
 public class PeopleExtractor extends BaseDataExtractor{
 
 
-    private final GenericSelectorFactory genericSelectorFactory;
+    private final GenericSelectorFactory genericSelectorFactory = new GenericSelectorFactory();
 
 
     @Autowired
-    public PeopleExtractor(DSLContext dsl, GenericSelectorFactory genericSelectorFactory) {
+    public PeopleExtractor(DSLContext dsl) {
         super(dsl);
-        this.genericSelectorFactory = genericSelectorFactory;
     }
 
 

--- a/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/TechnologyEOLDatabaseExtractor.java
+++ b/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/TechnologyEOLDatabaseExtractor.java
@@ -4,16 +4,17 @@ import com.khartec.waltz.data.EntityReferenceNameResolver;
 import com.khartec.waltz.data.application.ApplicationIdSelectorFactory;
 import com.khartec.waltz.model.EntityReference;
 import org.jooq.*;
+import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import spark.Request;
 
-
 import static com.khartec.waltz.common.Checks.checkNotNull;
 import static com.khartec.waltz.model.application.ApplicationIdSelectionOptions.mkOpts;
-import static com.khartec.waltz.schema.Tables.*;
+import static com.khartec.waltz.schema.Tables.DATABASE_INFORMATION;
+import static com.khartec.waltz.schema.Tables.ORGANISATIONAL_UNIT;
 import static com.khartec.waltz.schema.tables.Application.APPLICATION;
 import static com.khartec.waltz.web.WebUtilities.getEntityReference;
 import static com.khartec.waltz.web.WebUtilities.mkPath;
@@ -25,17 +26,15 @@ public class TechnologyEOLDatabaseExtractor extends BaseDataExtractor {
 
     private static final Logger LOG = LoggerFactory.getLogger(TechnologyEOLDatabaseExtractor.class);
     private final EntityReferenceNameResolver nameResolver;
-    private final ApplicationIdSelectorFactory applicationIdSelectorFactory;
+    private final ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
 
     @Autowired
     public TechnologyEOLDatabaseExtractor(DSLContext dsl,
-                                          EntityReferenceNameResolver nameResolver,
-                                          ApplicationIdSelectorFactory applicationIdSelectorFactory) {
+                                          EntityReferenceNameResolver nameResolver) {
         super(dsl);
         checkNotNull(nameResolver, "nameResolver cannot be null");
         checkNotNull(applicationIdSelectorFactory, "appIdSelectorFactory cannot be null");
         this.nameResolver = nameResolver;
-        this.applicationIdSelectorFactory = applicationIdSelectorFactory;
     }
 
 
@@ -46,7 +45,7 @@ public class TechnologyEOLDatabaseExtractor extends BaseDataExtractor {
             EntityReference ref = getReference(request);
             Select<Record1<Long>> appIdSelector = applicationIdSelectorFactory.apply(mkOpts(ref));
 
-            SelectConditionStep<Record> qry = dsl
+            SelectConditionStep<Record> qry = DSL
                     .selectDistinct(ORGANISATIONAL_UNIT.NAME.as("Org Unit"))
                     .select(APPLICATION.NAME.as("Application Name"), APPLICATION.ASSET_CODE.as("Asset Code"))
                     .select(DATABASE_INFORMATION.DATABASE_NAME.as("Database Name"),

--- a/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/TechnologyEOLServerExtractor.java
+++ b/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/TechnologyEOLServerExtractor.java
@@ -4,8 +4,7 @@ import com.khartec.waltz.data.EntityReferenceNameResolver;
 import com.khartec.waltz.data.application.ApplicationIdSelectorFactory;
 import com.khartec.waltz.model.EntityReference;
 import org.jooq.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jooq.impl.DSL;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import spark.Request;
@@ -22,20 +21,16 @@ import static spark.Spark.get;
 @Service
 public class TechnologyEOLServerExtractor extends BaseDataExtractor {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TechnologyEOLServerExtractor.class);
     private final EntityReferenceNameResolver nameResolver;
-    private final ApplicationIdSelectorFactory applicationIdSelectorFactory;
+    private final ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
 
 
     @Autowired
     public TechnologyEOLServerExtractor(DSLContext dsl,
-                                        EntityReferenceNameResolver nameResolver,
-                                        ApplicationIdSelectorFactory applicationIdSelectorFactory) {
+                                        EntityReferenceNameResolver nameResolver) {
         super(dsl);
         checkNotNull(nameResolver, "nameResolver cannot be null");
-        checkNotNull(applicationIdSelectorFactory, "appIdSelectorFactory cannot be null");
         this.nameResolver = nameResolver;
-        this.applicationIdSelectorFactory = applicationIdSelectorFactory;
     }
 
 
@@ -46,7 +41,7 @@ public class TechnologyEOLServerExtractor extends BaseDataExtractor {
             EntityReference ref = getReference(request);
             Select<Record1<Long>> appIdSelector = applicationIdSelectorFactory.apply(mkOpts(ref));
 
-            SelectConditionStep<Record> qry = dsl
+            SelectConditionStep<Record> qry = DSL
                     .selectDistinct(ORGANISATIONAL_UNIT.NAME.as("Org Unit"))
                     .select(APPLICATION.NAME.as("Application Name"), APPLICATION.ASSET_CODE.as("Asset Code"))
                     .select(SERVER_INFORMATION.HOSTNAME.as("Host Name"),


### PR DESCRIPTION
#4259 

@rovats - before I merge this want to give you a heads-up.  The selector factories are no longer spring beans and thus no longer autowired.  This solves a cyclical dependency problem.  Not sure if it affects any loaders you may have written which use waltz code