### PR TITLE
Relax maven version dependency slightly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,8 +324,8 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.5</version>
-                                    <message>"Waltz must be compiled using maven 3.5 or greater"</message>
+                                    <version>3.2</version>
+                                    <message>"Waltz must be compiled using maven 3.2 or greater"</message>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>${java.version}</version>


### PR DESCRIPTION
We can build with mvn 3.2 +, no need to require 3.5+